### PR TITLE
Display default field values in config output (Vibe Kanban)

### DIFF
--- a/sandbox/main.go
+++ b/sandbox/main.go
@@ -75,6 +75,9 @@ func main() {
 			if f.Unique {
 				fmt.Print(" [unique]")
 			}
+			if f.Default != nil {
+				fmt.Printf(" [default: %v]", f.Default)
+			}
 			if f.References != "" {
 				fmt.Printf(" -> %s", f.References)
 			}


### PR DESCRIPTION
## What changed

Added display of `default` field values when printing parsed config in the sandbox.

**Before:** Fields with a `default:` entry in `example.yaml` (e.g. `present: boolean, default: false`) were silently parsed but never shown in the output.

**After:** The output now includes `[default: <value>]` alongside other field annotations (`[required]`, `[unique]`, `-> ref`).

```
  attendance (3 fields)
    - lesson_id int -> lessons.id
    - student_id int -> students.id
    - present boolean [default: false]   ← now visible
```

## Why

The config structs (`AppConfig`, `DatabaseConfig`, `Model`, `Field`) already mapped every field from `example.yaml`, including `Default any`. However the sandbox output loop did not render it, making the parsed value invisible and leaving the struct coverage unverifiable at a glance. This change closes that gap.

## Implementation details

- `Field.Default` is typed as `any` to handle arbitrary YAML scalars (bool, int, string, etc.)
- The nil-check `if f.Default != nil` ensures fields without a default stay silent
- Uses `%v` formatting so any scalar type prints naturally

This PR was written using [Vibe Kanban](https://vibekanban.com)