### PR TITLE
Generate docker-compose.yml with app and PostgreSQL service (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generate a full-stack web application (database + server + client) from a single
 
 | Layer    | Technology        |
 |----------|-------------------|
-| Database | MySQL             |
+| Database | PostgreSQL        |
 | Server   | Go + Gin + GORM   |
 | Client   | React             |
 | Auth     | JWT               |
@@ -56,7 +56,7 @@ generated/
 
 ## Features
 
-- **Database** — MySQL migrations and GORM models
+- **Database** — PostgreSQL migrations and GORM models
 - **Server** — Gin REST API routes, JWT auth middleware
 - **Client** — React pages, components, API bindings
 - **Sync** — re-run `build` after config changes; only diffs are regenerated

--- a/sandbox/main.go
+++ b/sandbox/main.go
@@ -15,6 +15,9 @@ import (
 //go:embed templates/main.go.tmpl
 var mainTmpl string
 
+//go:embed templates/docker-compose.yml.tmpl
+var dockerComposeTmpl string
+
 type Config struct {
 	App      AppConfig      `yaml:"app"`
 	Database DatabaseConfig `yaml:"database"`
@@ -408,6 +411,21 @@ func GenerateMain(cfg *Config, appImport string) string {
 	return buf.String()
 }
 
+// GenerateDockerCompose returns a docker-compose.yml for the generated app,
+// wiring the Go server and a PostgreSQL service together.
+func GenerateDockerCompose(cfg *Config) string {
+	data := struct {
+		Port   int
+		DBName string
+	}{
+		Port:   cfg.App.Port,
+		DBName: cfg.Database.Name,
+	}
+	var buf strings.Builder
+	template.Must(template.New("docker-compose").Parse(dockerComposeTmpl)).Execute(&buf, data) //nolint:errcheck
+	return buf.String()
+}
+
 // GenerateGinRoutes returns Go source code with Gin CRUD handlers and a RegisterRoutes
 // function for every model. modelsImport is the full import path of the models package
 // (e.g. "myapp/models").
@@ -628,4 +646,10 @@ func main() {
 		log.Fatalf("write main.go: %v", err)
 	}
 	fmt.Println("Generated main.go")
+
+	compose := GenerateDockerCompose(cfg)
+	if err := os.WriteFile("docker-compose.yml", []byte(compose), 0644); err != nil {
+		log.Fatalf("write docker-compose.yml: %v", err)
+	}
+	fmt.Println("Generated docker-compose.yml")
 }

--- a/sandbox/main_test.go
+++ b/sandbox/main_test.go
@@ -236,6 +236,63 @@ func TestGenerateMain_RouterAndServer(t *testing.T) {
 	}
 }
 
+func TestGenerateDockerCompose_Services(t *testing.T) {
+	cfg := &Config{
+		App:      AppConfig{Name: "myapp", Port: 8080},
+		Database: DatabaseConfig{Host: "localhost", Name: "mydb"},
+		Models:   []Model{{Name: "users", Fields: []Field{{Name: "name", Type: "text"}}}},
+	}
+	out := GenerateDockerCompose(cfg)
+
+	for _, want := range []string{
+		"services:",
+		"app:",
+		"postgres:",
+		"image: postgres:16-alpine",
+		`"8080:8080"`,
+		"DB_HOST: postgres",
+		"POSTGRES_DB: mydb",
+		"postgres_data:",
+		"service_healthy",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing: %s", want)
+		}
+	}
+}
+
+func TestGenerateDockerCompose_PortAndDBName(t *testing.T) {
+	cfg := &Config{
+		App:      AppConfig{Name: "journal", Port: 3000},
+		Database: DatabaseConfig{Host: "localhost", Name: "attendance_db"},
+		Models:   []Model{{Name: "items", Fields: []Field{{Name: "title", Type: "text"}}}},
+	}
+	out := GenerateDockerCompose(cfg)
+
+	if !strings.Contains(out, `"3000:3000"`) {
+		t.Error("expected port 3000 in app service")
+	}
+	if !strings.Contains(out, "POSTGRES_DB: attendance_db") {
+		t.Error("expected POSTGRES_DB: attendance_db")
+	}
+	if !strings.Contains(out, "pg_isready") {
+		t.Error("expected pg_isready healthcheck")
+	}
+}
+
+func TestGenerateMain_DBHostEnv(t *testing.T) {
+	cfg := &Config{
+		App:      AppConfig{Name: "myapp", Port: 8080},
+		Database: DatabaseConfig{Host: "localhost", Name: "mydb"},
+		Models:   []Model{{Name: "items", Fields: []Field{{Name: "title", Type: "text"}}}},
+	}
+	out := GenerateMain(cfg, "myapp")
+
+	if !strings.Contains(out, `os.Getenv("DB_HOST")`) {
+		t.Error("expected DB_HOST env var reading in generated main.go")
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/sandbox/templates/docker-compose.yml.tmpl
+++ b/sandbox/templates/docker-compose.yml.tmpl
@@ -1,0 +1,32 @@
+services:
+  app:
+    build: .
+    ports:
+      - "{{.Port}}:{{.Port}}"
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:-secret}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-secret}
+      POSTGRES_DB: {{.DBName}}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d {{.DBName}}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/sandbox/templates/main.go.tmpl
+++ b/sandbox/templates/main.go.tmpl
@@ -14,6 +14,11 @@ import (
 )
 
 func main() {
+	dbHost := os.Getenv("DB_HOST")
+	if dbHost == "" {
+		dbHost = {{.DBHost}}
+	}
+
 	dbPort := os.Getenv("DB_PORT")
 	if dbPort == "" {
 		dbPort = "5432"
@@ -21,7 +26,7 @@ func main() {
 
 	dsn := fmt.Sprintf(
 		"host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
-		{{.DBHost}}, os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), {{.DBName}}, dbPort,
+		dbHost, os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), {{.DBName}}, dbPort,
 	)
 
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})


### PR DESCRIPTION
## What changed

- **New template** \`sandbox/templates/docker-compose.yml.tmpl\` — defines two services:
  - \`app\`: builds from the project directory, exposes the configured port, passes DB credentials via environment variables, and waits for postgres to be healthy before starting
  - \`postgres\`: \`postgres:16-alpine\` with a named volume, healthcheck via \`pg_isready\`, and credentials driven by \`\${DB_USER}\` / \`\${DB_PASSWORD}\` env vars (defaulting to safe placeholders)
- **\`sandbox/main.go\`** — embeds the new template and adds \`GenerateDockerCompose(cfg)\`, called in \`main()\` to write \`docker-compose.yml\` alongside the other generated artifacts
- **\`sandbox/templates/main.go.tmpl\`** — the generated app now reads \`DB_HOST\` from the environment first (falling back to the YAML-configured value), so the app connects to the \`postgres\` Docker service by its service name instead of \`localhost\`
- **\`README.md\`** — corrected the stack table and features section: MySQL → PostgreSQL (the codebase has used the PostgreSQL/GORM postgres driver throughout)
- **Tests** — three new test cases cover \`GenerateDockerCompose\` output (services, ports, DB name, healthcheck) and the \`DB_HOST\` env-var reading in the generated \`main.go\`

## Why

The generator already produced \`main.go\`, GORM models, Gin routes, and SQL migrations — but users still had to wire up infrastructure manually. Adding \`docker-compose.yml\` generation closes the loop: a single \`docker-compose up\` in the generated directory is enough to run the full stack locally.

The \`DB_HOST\` env override in \`main.go.tmpl\` is a prerequisite: without it the generated app would ignore Docker's internal DNS and always try \`localhost:5432\`, failing inside a container network.

## Implementation details

- The template uses Go's \`text/template\` (same pattern as \`main.go.tmpl\`) and is embedded with \`//go:embed\`
- Credentials are left as env-var interpolations (\`\${DB_USER:-postgres}\`) so users can supply real secrets without modifying generated files
- The \`postgres\` healthcheck uses \`pg_isready\` with \`condition: service_healthy\` on the app's \`depends_on\`, preventing race conditions on first boot

---

This PR was written using [Vibe Kanban](https://vibekanban.com)