### PR TITLE
Generate snake_case JSON tags for API response fields (Vibe Kanban)

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -324,7 +324,7 @@ func extractSize(sqlType string) string {
 	return ""
 }
 
-func buildGORMTag(f Field) string {
+func buildFieldTags(f Field) string {
 	var parts []string
 	parts = append(parts, "column:"+f.Name)
 	if size := extractSize(f.Type); size != "" {
@@ -339,19 +339,10 @@ func buildGORMTag(f Field) string {
 	if f.Default != nil {
 		parts = append(parts, "default:"+formatDefault(f.Default))
 	}
-	return `gorm:"` + strings.Join(parts, ";") + `"`
+	return `gorm:"` + strings.Join(parts, ";") + `" json:"` + f.Name + `"`
 }
 
 func GenerateGORMModels(models []Model, pkgName string) string {
-	needsTime := false
-	for _, m := range models {
-		for _, f := range m.Fields {
-			if sqlTypeToGo(f.Type) == "time.Time" {
-				needsTime = true
-			}
-		}
-	}
-
 	structNames := make(map[string]string, len(models))
 	for _, m := range models {
 		structNames[m.Name] = toPascalCase(toSingular(m.Name))
@@ -360,22 +351,27 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 	var sb strings.Builder
 	sb.WriteString("package " + pkgName + "\n\n")
 	sb.WriteString("import (\n")
-	if needsTime {
-		sb.WriteString("\t\"time\"\n\n")
-	}
+	sb.WriteString("\t\"time\"\n\n")
 	sb.WriteString("\t\"gorm.io/gorm\"\n")
 	sb.WriteString(")\n")
+
+	sb.WriteString("\ntype Base struct {\n")
+	sb.WriteString("\tID        uint           `gorm:\"primarykey\" json:\"id\"`\n")
+	sb.WriteString("\tCreatedAt time.Time      `json:\"created_at\"`\n")
+	sb.WriteString("\tUpdatedAt time.Time      `json:\"updated_at\"`\n")
+	sb.WriteString("\tDeletedAt gorm.DeletedAt `gorm:\"index\" json:\"deleted_at,omitempty\"`\n")
+	sb.WriteString("}\n")
 
 	for _, m := range models {
 		structName := structNames[m.Name]
 		sb.WriteString("\ntype " + structName + " struct {\n")
-		sb.WriteString("\tgorm.Model\n")
+		sb.WriteString("\tBase\n")
 
 		for _, f := range m.Fields {
 			fieldName := toPascalCase(f.Name)
 			goType := sqlTypeToGo(f.Type)
-			tag := buildGORMTag(f)
-			fmt.Fprintf(&sb, "\t%-20s %-12s `%s`\n", fieldName, goType, tag)
+			tags := buildFieldTags(f)
+			fmt.Fprintf(&sb, "\t%-20s %-12s `%s`\n", fieldName, goType, tags)
 
 			if f.References != "" {
 				parts := strings.SplitN(f.References, ".", 2)
@@ -387,7 +383,11 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 					if assocField == fieldName {
 						assocField = assocStruct
 					}
-					fmt.Fprintf(&sb, "\t%-20s %-12s `gorm:\"foreignKey:%s\"`\n", assocField, assocStruct, fieldName)
+					assocJsonName := strings.TrimSuffix(f.Name, "_id")
+					if assocJsonName == f.Name {
+						assocJsonName = strings.TrimSuffix(f.Name, "_ID")
+					}
+					fmt.Fprintf(&sb, "\t%-20s %-12s `gorm:\"foreignKey:%s\" json:\"%s\"`\n", assocField, assocStruct, fieldName, assocJsonName)
 				}
 			}
 		}

--- a/sandbox/main.go
+++ b/sandbox/main.go
@@ -311,7 +311,7 @@ func extractSize(sqlType string) string {
 }
 
 // buildGORMTag builds the `gorm:"..."` tag value for a field.
-func buildGORMTag(f Field) string {
+func buildFieldTags(f Field) string {
 	var parts []string
 	parts = append(parts, "column:"+f.Name)
 	if size := extractSize(f.Type); size != "" {
@@ -326,21 +326,11 @@ func buildGORMTag(f Field) string {
 	if f.Default != nil {
 		parts = append(parts, "default:"+formatDefault(f.Default))
 	}
-	return `gorm:"` + strings.Join(parts, ";") + `"`
+	return `gorm:"` + strings.Join(parts, ";") + `" json:"` + f.Name + `"`
 }
 
 // GenerateGORMModels returns Go source code with GORM model structs for all models.
 func GenerateGORMModels(models []Model, pkgName string) string {
-	// Check if time.Time is needed for any field.
-	needsTime := false
-	for _, m := range models {
-		for _, f := range m.Fields {
-			if sqlTypeToGo(f.Type) == "time.Time" {
-				needsTime = true
-			}
-		}
-	}
-
 	// Build struct name lookup: table name → struct name.
 	structNames := make(map[string]string, len(models))
 	for _, m := range models {
@@ -350,22 +340,27 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 	var sb strings.Builder
 	sb.WriteString("package " + pkgName + "\n\n")
 	sb.WriteString("import (\n")
-	if needsTime {
-		sb.WriteString("\t\"time\"\n\n")
-	}
+	sb.WriteString("\t\"time\"\n\n")
 	sb.WriteString("\t\"gorm.io/gorm\"\n")
 	sb.WriteString(")\n")
+
+	sb.WriteString("\ntype Base struct {\n")
+	sb.WriteString("\tID        uint           `gorm:\"primarykey\" json:\"id\"`\n")
+	sb.WriteString("\tCreatedAt time.Time      `json:\"created_at\"`\n")
+	sb.WriteString("\tUpdatedAt time.Time      `json:\"updated_at\"`\n")
+	sb.WriteString("\tDeletedAt gorm.DeletedAt `gorm:\"index\" json:\"deleted_at,omitempty\"`\n")
+	sb.WriteString("}\n")
 
 	for _, m := range models {
 		structName := structNames[m.Name]
 		sb.WriteString("\ntype " + structName + " struct {\n")
-		sb.WriteString("\tgorm.Model\n")
+		sb.WriteString("\tBase\n")
 
 		for _, f := range m.Fields {
 			fieldName := toPascalCase(f.Name)
 			goType := sqlTypeToGo(f.Type)
-			tag := buildGORMTag(f)
-			fmt.Fprintf(&sb, "\t%-20s %-12s `%s`\n", fieldName, goType, tag)
+			tags := buildFieldTags(f)
+			fmt.Fprintf(&sb, "\t%-20s %-12s `%s`\n", fieldName, goType, tags)
 
 			// For FK fields, add a typed association field.
 			if f.References != "" {
@@ -379,7 +374,11 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 					if assocField == fieldName {
 						assocField = assocStruct
 					}
-					fmt.Fprintf(&sb, "\t%-20s %-12s `gorm:\"foreignKey:%s\"`\n", assocField, assocStruct, fieldName)
+					assocJsonName := strings.TrimSuffix(f.Name, "_id")
+					if assocJsonName == f.Name {
+						assocJsonName = strings.TrimSuffix(f.Name, "_ID")
+					}
+					fmt.Fprintf(&sb, "\t%-20s %-12s `gorm:\"foreignKey:%s\" json:\"%s\"`\n", assocField, assocStruct, fieldName, assocJsonName)
 				}
 			}
 		}

--- a/sandbox/main_test.go
+++ b/sandbox/main_test.go
@@ -379,6 +379,62 @@ func TestGenerateEnv_Defaults(t *testing.T) {
 	}
 }
 
+func TestGenerateGORMModels_SnakeCaseJSONTags(t *testing.T) {
+	models := []Model{
+		{Name: "students", Fields: []Field{
+			{Name: "first_name", Type: "varchar(100)", Required: true},
+			{Name: "email", Type: "varchar(255)", Unique: true},
+		}},
+	}
+	out := GenerateGORMModels(models, "models")
+
+	for _, want := range []string{
+		`json:"first_name"`,
+		`json:"email"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing json tag %s in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerateGORMModels_BaseStructWithSnakeCaseTags(t *testing.T) {
+	models := []Model{
+		{Name: "items", Fields: []Field{{Name: "title", Type: "text"}}},
+	}
+	out := GenerateGORMModels(models, "models")
+
+	for _, want := range []string{
+		`json:"id"`,
+		`json:"created_at"`,
+		`json:"updated_at"`,
+		`json:"deleted_at,omitempty"`,
+		"type Base struct",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+
+	if strings.Contains(out, "gorm.Model") {
+		t.Error("output should not embed gorm.Model directly; expected custom Base struct")
+	}
+}
+
+func TestGenerateGORMModels_AssociationJSONTag(t *testing.T) {
+	models := []Model{
+		{Name: "subjects", Fields: []Field{{Name: "name", Type: "text"}}},
+		{Name: "lessons", Fields: []Field{
+			{Name: "subject_id", Type: "int", References: "subjects.id"},
+		}},
+	}
+	out := GenerateGORMModels(models, "models")
+
+	if !strings.Contains(out, `json:"subject"`) {
+		t.Errorf("expected json:\"subject\" for association field, got:\n%s", out)
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a


### PR DESCRIPTION
## What changed

- **`buildGORMTag` → `buildFieldTags`**: The tag-building function now appends a `json:"<field_name>"` tag alongside the existing `gorm:` tag for every model field. Field names sourced from the YAML config are already in snake_case, so they are used directly.
- **Custom `Base` struct**: Replaced direct embedding of `gorm.Model` with a generated `Base` struct that carries explicit snake_case JSON tags (`id`, `created_at`, `updated_at`, `deleted_at`). Previously, `gorm.Model`'s fields had no JSON tags, causing them to serialize as `ID`, `CreatedAt`, `UpdatedAt`, `DeletedAt` in API responses.
- **Association field JSON tags**: Foreign-key association fields (e.g. `Subject` on a `Lesson`) now receive a `json:"<assoc_name>"` tag derived by stripping the `_id` suffix from the FK field name.
- Changes applied consistently to both `internal/generator/generator.go` and `sandbox/main.go`.
- New tests added in `sandbox/main_test.go` covering all three cases.

## Why

The generated API was returning JSON fields in PascalCase (e.g. `FirstName`, `SubjectID`, `CreatedAt`) because Go structs without explicit `json:` tags use the exported field name as-is. REST APIs conventionally use snake_case field names, so this change ensures the generated server outputs properly formatted JSON responses out of the box.

## Implementation details

- `"time"` is now always imported in generated model files (previously conditional) since the `Base` struct always uses `time.Time`.
- `gorm.DeletedAt` is preserved in `Base` so soft-delete behaviour remains intact.
- The `deleted_at` field uses `omitempty` to avoid serializing `null` for non-deleted records.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)