### PR TITLE
Add shutdown.sh generation to mirror dev.sh (Vibe Kanban)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -79,6 +79,9 @@ var buildCmd = &cobra.Command{
 			{"Generating dev.sh", func() error {
 				return writeExecutable(filepath.Join(out, "dev.sh"), generator.GenerateDevScript(cfg))
 			}},
+			{"Generating shutdown.sh", func() error {
+				return writeExecutable(filepath.Join(out, "shutdown.sh"), generator.GenerateShutdownScript())
+			}},
 		}
 
 		if err := os.MkdirAll(out, 0755); err != nil {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -26,6 +26,9 @@ var envTmpl string
 //go:embed templates/dev.sh.tmpl
 var devShTmpl string
 
+//go:embed templates/shutdown.sh.tmpl
+var shutdownShTmpl string
+
 type Config struct {
 	App      AppConfig      `yaml:"app"`
 	Database DatabaseConfig `yaml:"database"`
@@ -480,6 +483,12 @@ func GenerateDevScript(cfg *Config) string {
 	}
 	var buf strings.Builder
 	template.Must(template.New("dev.sh").Parse(devShTmpl)).Execute(&buf, data) //nolint:errcheck
+	return buf.String()
+}
+
+func GenerateShutdownScript() string {
+	var buf strings.Builder
+	template.Must(template.New("shutdown.sh").Parse(shutdownShTmpl)).Execute(&buf, nil) //nolint:errcheck
 	return buf.String()
 }
 

--- a/internal/generator/templates/shutdown.sh.tmpl
+++ b/internal/generator/templates/shutdown.sh.tmpl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "▸ Stopping containers..."
+docker compose down
+
+echo "Done."


### PR DESCRIPTION
## What changed

- Added \`internal/generator/templates/shutdown.sh.tmpl\` — a bash template that runs \`docker compose down\` to stop all containers
- Added \`GenerateShutdownScript()\` function in \`internal/generator/generator.go\` with an embedded template
- Added a \`"Generating shutdown.sh"\` build step in \`cmd/build.go\` that writes the script as an executable

## Why

The generator already produced a \`dev.sh\` script to start the stack (spin up Postgres, wait for readiness, apply migrations, run the server). There was no counterpart to tear it down cleanly. This PR adds \`shutdown.sh\` as the reverse: a single command that stops all Docker Compose services.

## Implementation details

- The template has no dynamic variables since shutdown requires no config-specific values — \`GenerateShutdownScript\` therefore takes no arguments
- The script uses \`set -euo pipefail\` and \`cd "\$(dirname "\$0")"\` consistent with \`dev.sh\` conventions
- Written with \`0755\` permissions via the existing \`writeExecutable\` helper, same as \`dev.sh\`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)