### PR TITLE
Add React client generation from YAML config (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,23 @@ dist/
 │   ├── 001_initial.up.sql
 │   └── 001_initial.down.sql
 ├── models/
-│   └── models.go                  # GORM structs
-└── routes/
-    └── routes.go                  # Gin CRUD handlers
+│   └── models.go                  # GORM structs (snake_case JSON tags)
+├── routes/
+│   └── routes.go                  # Gin CRUD handlers
+└── client/                        # React + TypeScript frontend
+    ├── package.json               # react, react-router-dom, vite
+    ├── index.html
+    ├── vite.config.ts             # dev proxy → Go backend
+    ├── tsconfig.json
+    └── src/
+        ├── main.tsx
+        ├── App.tsx                # nav + routes per model
+        ├── types/
+        │   └── {model}.ts        # TypeScript interfaces
+        ├── api/
+        │   └── {model}.ts        # fetch wrappers (list/get/create/update/delete)
+        └── pages/
+            └── {Model}Page.tsx   # CRUD table + inline form
 ```
 
 ## Getting Started

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -82,6 +82,46 @@ var buildCmd = &cobra.Command{
 			{"Generating shutdown.sh", func() error {
 				return writeExecutable(filepath.Join(out, "shutdown.sh"), generator.GenerateShutdownScript())
 			}},
+			{"Generating client", func() error {
+				clientDir := filepath.Join(out, "client")
+				srcDir := filepath.Join(clientDir, "src")
+				for _, dir := range []string{
+					filepath.Join(srcDir, "types"),
+					filepath.Join(srcDir, "api"),
+					filepath.Join(srcDir, "pages"),
+				} {
+					if err := os.MkdirAll(dir, 0755); err != nil {
+						return err
+					}
+				}
+				static := map[string]string{
+					filepath.Join(clientDir, "package.json"):   generator.GenerateReactPackageJSON(cfg),
+					filepath.Join(clientDir, "index.html"):     generator.GenerateReactIndexHTML(cfg),
+					filepath.Join(clientDir, "vite.config.ts"): generator.GenerateReactViteConfig(cfg),
+					filepath.Join(clientDir, "tsconfig.json"):  generator.GenerateReactTsConfig(),
+					filepath.Join(srcDir, "main.tsx"):          generator.GenerateReactMain(),
+					filepath.Join(srcDir, "App.tsx"):           generator.GenerateReactApp(cfg.Models),
+				}
+				for path, content := range static {
+					if err := writeFile(path, content); err != nil {
+						return err
+					}
+				}
+				for _, m := range cfg.Models {
+					base := generator.ModelFileBasename(m)
+					structName := generator.ModelStructName(m)
+					if err := writeFile(filepath.Join(srcDir, "types", base+".ts"), generator.GenerateReactTypes(m)); err != nil {
+						return err
+					}
+					if err := writeFile(filepath.Join(srcDir, "api", base+".ts"), generator.GenerateReactAPI(m)); err != nil {
+						return err
+					}
+					if err := writeFile(filepath.Join(srcDir, "pages", structName+"Page.tsx"), generator.GenerateReactPage(m)); err != nil {
+						return err
+					}
+				}
+				return nil
+			}},
 		}
 
 		if err := os.MkdirAll(out, 0755); err != nil {

--- a/internal/generator/client.go
+++ b/internal/generator/client.go
@@ -1,0 +1,410 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ModelStructName returns the PascalCase singular struct name for a model (e.g. "students" → "Student").
+func ModelStructName(m Model) string {
+	return toPascalCase(toSingular(m.Name))
+}
+
+// ModelFileBasename returns the singular snake_case file basename for a model (e.g. "students" → "student").
+func ModelFileBasename(m Model) string {
+	return toSingular(m.Name)
+}
+
+// sqlTypeToTS maps a SQL type to the corresponding TypeScript type.
+func sqlTypeToTS(sqlType string) string {
+	lower := strings.ToLower(sqlType)
+	switch {
+	case strings.HasPrefix(lower, "varchar"), strings.HasPrefix(lower, "char"), lower == "text", lower == "uuid":
+		return "string"
+	case lower == "int", lower == "bigint", lower == "smallint":
+		return "number"
+	case lower == "boolean", lower == "bool":
+		return "boolean"
+	case lower == "date", lower == "datetime", lower == "timestamp":
+		return "string"
+	case lower == "float", lower == "double":
+		return "number"
+	case strings.HasPrefix(lower, "decimal"):
+		return "number"
+	default:
+		return "unknown"
+	}
+}
+
+// tsInputDefault returns the default form value for a SQL type.
+func tsInputDefault(sqlType string) string {
+	lower := strings.ToLower(sqlType)
+	switch {
+	case lower == "boolean", lower == "bool":
+		return "false"
+	case lower == "int", lower == "bigint", lower == "smallint", lower == "float", lower == "double":
+		return "0"
+	case strings.HasPrefix(lower, "decimal"):
+		return "0"
+	default:
+		return "''"
+	}
+}
+
+// tsInputType returns the HTML input type for a SQL type.
+func tsInputType(sqlType string) string {
+	lower := strings.ToLower(sqlType)
+	switch {
+	case lower == "boolean", lower == "bool":
+		return "checkbox"
+	case lower == "int", lower == "bigint", lower == "smallint", lower == "float", lower == "double":
+		return "number"
+	case strings.HasPrefix(lower, "decimal"):
+		return "number"
+	case lower == "date":
+		return "date"
+	default:
+		return "text"
+	}
+}
+
+// GenerateReactPackageJSON returns package.json for the React client.
+func GenerateReactPackageJSON(cfg *Config) string {
+	return fmt.Sprintf(`{
+  "name": "%s-client",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "~5.6.2",
+    "vite": "^6.0.5"
+  }
+}
+`, cfg.App.Name)
+}
+
+// GenerateReactIndexHTML returns index.html for the React client.
+func GenerateReactIndexHTML(cfg *Config) string {
+	return fmt.Sprintf(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>%s</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`, cfg.App.Name)
+}
+
+// GenerateReactViteConfig returns vite.config.ts for the React client.
+func GenerateReactViteConfig(cfg *Config) string {
+	var sb strings.Builder
+	sb.WriteString("import { defineConfig } from 'vite'\n")
+	sb.WriteString("import react from '@vitejs/plugin-react'\n\n")
+	sb.WriteString("export default defineConfig({\n")
+	sb.WriteString("  plugins: [react()],\n")
+	sb.WriteString("  server: {\n")
+	sb.WriteString("    proxy: {\n")
+	for _, m := range cfg.Models {
+		fmt.Fprintf(&sb, "      '/%s': 'http://localhost:%d',\n", m.Name, cfg.App.Port)
+	}
+	sb.WriteString("    },\n")
+	sb.WriteString("  },\n")
+	sb.WriteString("})\n")
+	return sb.String()
+}
+
+// GenerateReactTsConfig returns tsconfig.json for the React client.
+func GenerateReactTsConfig() string {
+	return `{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}
+`
+}
+
+// GenerateReactMain returns src/main.tsx for the React client.
+func GenerateReactMain() string {
+	return `import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)
+`
+}
+
+// GenerateReactApp returns src/App.tsx with navigation and routes for all models.
+func GenerateReactApp(models []Model) string {
+	var sb strings.Builder
+	sb.WriteString("import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';\n")
+	for _, m := range models {
+		structName := toPascalCase(toSingular(m.Name))
+		fmt.Fprintf(&sb, "import %sPage from './pages/%sPage';\n", structName, structName)
+	}
+	sb.WriteString("\nexport default function App() {\n")
+	sb.WriteString("  return (\n")
+	sb.WriteString("    <BrowserRouter>\n")
+	sb.WriteString("      <nav>\n")
+	for i, m := range models {
+		structName := toPascalCase(toSingular(m.Name))
+		if i > 0 {
+			sb.WriteString("        {' | '}\n")
+		}
+		fmt.Fprintf(&sb, "        <NavLink to=\"/%s\">%s</NavLink>\n", m.Name, structName)
+	}
+	sb.WriteString("      </nav>\n")
+	sb.WriteString("      <main>\n")
+	sb.WriteString("        <Routes>\n")
+	for _, m := range models {
+		structName := toPascalCase(toSingular(m.Name))
+		fmt.Fprintf(&sb, "          <Route path=\"/%s\" element={<%sPage />} />\n", m.Name, structName)
+	}
+	sb.WriteString("        </Routes>\n")
+	sb.WriteString("      </main>\n")
+	sb.WriteString("    </BrowserRouter>\n")
+	sb.WriteString("  );\n")
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+// GenerateReactTypes returns src/types/{model}.ts with TypeScript interfaces for a model.
+func GenerateReactTypes(m Model) string {
+	structName := toPascalCase(toSingular(m.Name))
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "export interface %s {\n", structName)
+	sb.WriteString("  id: number;\n")
+	for _, f := range m.Fields {
+		tsType := sqlTypeToTS(f.Type)
+		if f.Required {
+			fmt.Fprintf(&sb, "  %s: %s;\n", f.Name, tsType)
+		} else {
+			fmt.Fprintf(&sb, "  %s?: %s;\n", f.Name, tsType)
+		}
+	}
+	sb.WriteString("  created_at: string;\n")
+	sb.WriteString("  updated_at: string;\n")
+	sb.WriteString("  deleted_at?: string;\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export type Create%sInput = {\n", structName)
+	for _, f := range m.Fields {
+		tsType := sqlTypeToTS(f.Type)
+		fmt.Fprintf(&sb, "  %s: %s;\n", f.Name, tsType)
+	}
+	sb.WriteString("};\n")
+
+	return sb.String()
+}
+
+// GenerateReactAPI returns src/api/{model}.ts with fetch wrappers for a model.
+func GenerateReactAPI(m Model) string {
+	singular := toSingular(m.Name)
+	structName := toPascalCase(singular)
+	pluralName := toPascalCase(m.Name)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "import type { %s, Create%sInput } from '../types/%s';\n\n", structName, structName, singular)
+	fmt.Fprintf(&sb, "const BASE = '/%s';\n\n", m.Name)
+
+	fmt.Fprintf(&sb, "export async function list%s(): Promise<%s[]> {\n", pluralName, structName)
+	sb.WriteString("  const res = await fetch(BASE);\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function get%s(id: number): Promise<%s> {\n", structName, structName)
+	sb.WriteString("  const res = await fetch(`${BASE}/${id}`);\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function create%s(data: Create%sInput): Promise<%s> {\n", structName, structName, structName)
+	sb.WriteString("  const res = await fetch(BASE, {\n")
+	sb.WriteString("    method: 'POST',\n")
+	sb.WriteString("    headers: { 'Content-Type': 'application/json' },\n")
+	sb.WriteString("    body: JSON.stringify(data),\n")
+	sb.WriteString("  });\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function update%s(id: number, data: Partial<Create%sInput>): Promise<%s> {\n", structName, structName, structName)
+	sb.WriteString("  const res = await fetch(`${BASE}/${id}`, {\n")
+	sb.WriteString("    method: 'PUT',\n")
+	sb.WriteString("    headers: { 'Content-Type': 'application/json' },\n")
+	sb.WriteString("    body: JSON.stringify(data),\n")
+	sb.WriteString("  });\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function delete%s(id: number): Promise<void> {\n", structName)
+	sb.WriteString("  const res = await fetch(`${BASE}/${id}`, { method: 'DELETE' });\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("}\n")
+
+	return sb.String()
+}
+
+// GenerateReactPage returns src/pages/{Model}Page.tsx with a CRUD table and form for a model.
+func GenerateReactPage(m Model) string {
+	singular := toSingular(m.Name)
+	structName := toPascalCase(singular)
+	pluralName := toPascalCase(m.Name)
+	componentName := structName + "Page"
+
+	var sb strings.Builder
+
+	// Imports
+	fmt.Fprintf(&sb, "import { useState, useEffect } from 'react';\n")
+	fmt.Fprintf(&sb, "import type { %s, Create%sInput } from '../types/%s';\n", structName, structName, singular)
+	fmt.Fprintf(&sb, "import { list%s, create%s, update%s, delete%s } from '../api/%s';\n\n", pluralName, structName, structName, structName, singular)
+
+	// EMPTY_FORM
+	fmt.Fprintf(&sb, "const EMPTY_FORM: Create%sInput = {\n", structName)
+	for _, f := range m.Fields {
+		fmt.Fprintf(&sb, "  %s: %s,\n", f.Name, tsInputDefault(f.Type))
+	}
+	sb.WriteString("};\n\n")
+
+	// Component
+	fmt.Fprintf(&sb, "export default function %s() {\n", componentName)
+	fmt.Fprintf(&sb, "  const [items, setItems] = useState<%s[]>([]);\n", structName)
+	fmt.Fprintf(&sb, "  const [editing, setEditing] = useState<%s | null>(null);\n", structName)
+	fmt.Fprintf(&sb, "  const [form, setForm] = useState<Create%sInput>(EMPTY_FORM);\n", structName)
+	sb.WriteString("  const [showForm, setShowForm] = useState(false);\n\n")
+
+	sb.WriteString("  useEffect(() => { load(); }, []);\n\n")
+
+	fmt.Fprintf(&sb, "  async function load() {\n")
+	fmt.Fprintf(&sb, "    try { setItems(await list%s()); } catch (e) { console.error(e); }\n", pluralName)
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  function openCreate() {\n")
+	sb.WriteString("    setEditing(null); setForm(EMPTY_FORM); setShowForm(true);\n")
+	sb.WriteString("  }\n\n")
+
+	fmt.Fprintf(&sb, "  function openEdit(item: %s) {\n", structName)
+	sb.WriteString("    setEditing(item);\n")
+	sb.WriteString("    setForm({\n")
+	for _, f := range m.Fields {
+		if f.Required {
+			fmt.Fprintf(&sb, "      %s: item.%s,\n", f.Name, f.Name)
+		} else {
+			fmt.Fprintf(&sb, "      %s: item.%s ?? %s,\n", f.Name, f.Name, tsInputDefault(f.Type))
+		}
+	}
+	sb.WriteString("    });\n")
+	sb.WriteString("    setShowForm(true);\n")
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  async function handleSubmit(e: React.FormEvent) {\n")
+	sb.WriteString("    e.preventDefault();\n")
+	sb.WriteString("    try {\n")
+	fmt.Fprintf(&sb, "      if (editing) await update%s(editing.id, form);\n", structName)
+	fmt.Fprintf(&sb, "      else await create%s(form);\n", structName)
+	sb.WriteString("      setShowForm(false); load();\n")
+	sb.WriteString("    } catch (e) { console.error(e); }\n")
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  async function handleDelete(id: number) {\n")
+	sb.WriteString("    if (!confirm('Delete?')) return;\n")
+	fmt.Fprintf(&sb, "    try { await delete%s(id); load(); } catch (e) { console.error(e); }\n", structName)
+	sb.WriteString("  }\n\n")
+
+	// JSX
+	sb.WriteString("  return (\n")
+	sb.WriteString("    <div>\n")
+	fmt.Fprintf(&sb, "      <h1>%s</h1>\n", m.Name)
+	sb.WriteString("      <button onClick={openCreate}>+ New</button>\n")
+
+	sb.WriteString("      {showForm && (\n")
+	sb.WriteString("        <form onSubmit={handleSubmit}>\n")
+	for _, f := range m.Fields {
+		inputType := tsInputType(f.Type)
+		if inputType == "checkbox" {
+			fmt.Fprintf(&sb, "          <label>%s <input type=\"checkbox\" checked={form.%s as boolean} onChange={e => setForm({...form, %s: e.target.checked})} /></label>\n", f.Name, f.Name, f.Name)
+		} else if inputType == "number" {
+			reqAttr := ""
+			if f.Required {
+				reqAttr = " required"
+			}
+			fmt.Fprintf(&sb, "          <label>%s <input type=\"number\" value={form.%s as number} onChange={e => setForm({...form, %s: Number(e.target.value)})}%s /></label>\n", f.Name, f.Name, f.Name, reqAttr)
+		} else {
+			reqAttr := ""
+			if f.Required {
+				reqAttr = " required"
+			}
+			fmt.Fprintf(&sb, "          <label>%s <input type=\"%s\" value={form.%s as string} onChange={e => setForm({...form, %s: e.target.value})}%s /></label>\n", f.Name, inputType, f.Name, f.Name, reqAttr)
+		}
+	}
+	sb.WriteString("          <button type=\"submit\">{editing ? 'Save' : 'Create'}</button>\n")
+	sb.WriteString("          <button type=\"button\" onClick={() => setShowForm(false)}>Cancel</button>\n")
+	sb.WriteString("        </form>\n")
+	sb.WriteString("      )}\n")
+
+	sb.WriteString("      <table>\n")
+	sb.WriteString("        <thead><tr><th>id</th>")
+	for _, f := range m.Fields {
+		fmt.Fprintf(&sb, "<th>%s</th>", f.Name)
+	}
+	sb.WriteString("<th></th></tr></thead>\n")
+	sb.WriteString("        <tbody>\n")
+	sb.WriteString("          {items.map(item => (\n")
+	sb.WriteString("            <tr key={item.id}>\n")
+	sb.WriteString("              <td>{item.id}</td>\n")
+	for _, f := range m.Fields {
+		if sqlTypeToTS(f.Type) == "boolean" {
+			fmt.Fprintf(&sb, "              <td>{item.%s ? 'yes' : 'no'}</td>\n", f.Name)
+		} else {
+			fmt.Fprintf(&sb, "              <td>{item.%s}</td>\n", f.Name)
+		}
+	}
+	sb.WriteString("              <td>\n")
+	sb.WriteString("                <button onClick={() => openEdit(item)}>Edit</button>\n")
+	sb.WriteString("                <button onClick={() => handleDelete(item.id)}>Del</button>\n")
+	sb.WriteString("              </td>\n")
+	sb.WriteString("            </tr>\n")
+	sb.WriteString("          ))}\n")
+	sb.WriteString("        </tbody>\n")
+	sb.WriteString("      </table>\n")
+	sb.WriteString("    </div>\n")
+	sb.WriteString("  );\n")
+	sb.WriteString("}\n")
+
+	return sb.String()
+}

--- a/sandbox/main.go
+++ b/sandbox/main.go
@@ -362,11 +362,9 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 			tags := buildFieldTags(f)
 			fmt.Fprintf(&sb, "\t%-20s %-12s `%s`\n", fieldName, goType, tags)
 
-			// For FK fields, add a typed association field.
 			if f.References != "" {
 				parts := strings.SplitN(f.References, ".", 2)
 				if assocStruct, ok := structNames[parts[0]]; ok {
-					// Strip "ID" or "Id" suffix to derive association field name.
 					assocField := strings.TrimSuffix(fieldName, "ID")
 					if assocField == fieldName {
 						assocField = strings.TrimSuffix(fieldName, "Id")
@@ -385,6 +383,392 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 
 		sb.WriteString("}\n")
 	}
+
+	return sb.String()
+}
+
+// ModelStructName returns the PascalCase singular struct name for a model.
+func ModelStructName(m Model) string {
+	return toPascalCase(toSingular(m.Name))
+}
+
+// ModelFileBasename returns the singular snake_case file basename for a model.
+func ModelFileBasename(m Model) string {
+	return toSingular(m.Name)
+}
+
+// sqlTypeToTS maps a SQL type to the corresponding TypeScript type.
+func sqlTypeToTS(sqlType string) string {
+	lower := strings.ToLower(sqlType)
+	switch {
+	case strings.HasPrefix(lower, "varchar"), strings.HasPrefix(lower, "char"), lower == "text", lower == "uuid":
+		return "string"
+	case lower == "int", lower == "bigint", lower == "smallint":
+		return "number"
+	case lower == "boolean", lower == "bool":
+		return "boolean"
+	case lower == "date", lower == "datetime", lower == "timestamp":
+		return "string"
+	case lower == "float", lower == "double":
+		return "number"
+	case strings.HasPrefix(lower, "decimal"):
+		return "number"
+	default:
+		return "unknown"
+	}
+}
+
+func tsInputDefault(sqlType string) string {
+	lower := strings.ToLower(sqlType)
+	switch {
+	case lower == "boolean", lower == "bool":
+		return "false"
+	case lower == "int", lower == "bigint", lower == "smallint", lower == "float", lower == "double":
+		return "0"
+	case strings.HasPrefix(lower, "decimal"):
+		return "0"
+	default:
+		return "''"
+	}
+}
+
+func tsInputType(sqlType string) string {
+	lower := strings.ToLower(sqlType)
+	switch {
+	case lower == "boolean", lower == "bool":
+		return "checkbox"
+	case lower == "int", lower == "bigint", lower == "smallint", lower == "float", lower == "double":
+		return "number"
+	case strings.HasPrefix(lower, "decimal"):
+		return "number"
+	case lower == "date":
+		return "date"
+	default:
+		return "text"
+	}
+}
+
+func GenerateReactPackageJSON(cfg *Config) string {
+	return fmt.Sprintf(`{
+  "name": "%s-client",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "~5.6.2",
+    "vite": "^6.0.5"
+  }
+}
+`, cfg.App.Name)
+}
+
+func GenerateReactIndexHTML(cfg *Config) string {
+	return fmt.Sprintf(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>%s</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`, cfg.App.Name)
+}
+
+func GenerateReactViteConfig(cfg *Config) string {
+	var sb strings.Builder
+	sb.WriteString("import { defineConfig } from 'vite'\n")
+	sb.WriteString("import react from '@vitejs/plugin-react'\n\n")
+	sb.WriteString("export default defineConfig({\n")
+	sb.WriteString("  plugins: [react()],\n")
+	sb.WriteString("  server: {\n")
+	sb.WriteString("    proxy: {\n")
+	for _, m := range cfg.Models {
+		fmt.Fprintf(&sb, "      '/%s': 'http://localhost:%d',\n", m.Name, cfg.App.Port)
+	}
+	sb.WriteString("    },\n")
+	sb.WriteString("  },\n")
+	sb.WriteString("})\n")
+	return sb.String()
+}
+
+func GenerateReactTsConfig() string {
+	return `{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}
+`
+}
+
+func GenerateReactMain() string {
+	return `import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)
+`
+}
+
+func GenerateReactApp(models []Model) string {
+	var sb strings.Builder
+	sb.WriteString("import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';\n")
+	for _, m := range models {
+		structName := toPascalCase(toSingular(m.Name))
+		fmt.Fprintf(&sb, "import %sPage from './pages/%sPage';\n", structName, structName)
+	}
+	sb.WriteString("\nexport default function App() {\n")
+	sb.WriteString("  return (\n")
+	sb.WriteString("    <BrowserRouter>\n")
+	sb.WriteString("      <nav>\n")
+	for i, m := range models {
+		structName := toPascalCase(toSingular(m.Name))
+		if i > 0 {
+			sb.WriteString("        {' | '}\n")
+		}
+		fmt.Fprintf(&sb, "        <NavLink to=\"/%s\">%s</NavLink>\n", m.Name, structName)
+	}
+	sb.WriteString("      </nav>\n")
+	sb.WriteString("      <main>\n")
+	sb.WriteString("        <Routes>\n")
+	for _, m := range models {
+		structName := toPascalCase(toSingular(m.Name))
+		fmt.Fprintf(&sb, "          <Route path=\"/%s\" element={<%sPage />} />\n", m.Name, structName)
+	}
+	sb.WriteString("        </Routes>\n")
+	sb.WriteString("      </main>\n")
+	sb.WriteString("    </BrowserRouter>\n")
+	sb.WriteString("  );\n")
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func GenerateReactTypes(m Model) string {
+	structName := toPascalCase(toSingular(m.Name))
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "export interface %s {\n", structName)
+	sb.WriteString("  id: number;\n")
+	for _, f := range m.Fields {
+		tsType := sqlTypeToTS(f.Type)
+		if f.Required {
+			fmt.Fprintf(&sb, "  %s: %s;\n", f.Name, tsType)
+		} else {
+			fmt.Fprintf(&sb, "  %s?: %s;\n", f.Name, tsType)
+		}
+	}
+	sb.WriteString("  created_at: string;\n")
+	sb.WriteString("  updated_at: string;\n")
+	sb.WriteString("  deleted_at?: string;\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export type Create%sInput = {\n", structName)
+	for _, f := range m.Fields {
+		tsType := sqlTypeToTS(f.Type)
+		fmt.Fprintf(&sb, "  %s: %s;\n", f.Name, tsType)
+	}
+	sb.WriteString("};\n")
+
+	return sb.String()
+}
+
+func GenerateReactAPI(m Model) string {
+	singular := toSingular(m.Name)
+	structName := toPascalCase(singular)
+	pluralName := toPascalCase(m.Name)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "import type { %s, Create%sInput } from '../types/%s';\n\n", structName, structName, singular)
+	fmt.Fprintf(&sb, "const BASE = '/%s';\n\n", m.Name)
+
+	fmt.Fprintf(&sb, "export async function list%s(): Promise<%s[]> {\n", pluralName, structName)
+	sb.WriteString("  const res = await fetch(BASE);\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function get%s(id: number): Promise<%s> {\n", structName, structName)
+	sb.WriteString("  const res = await fetch(`${BASE}/${id}`);\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function create%s(data: Create%sInput): Promise<%s> {\n", structName, structName, structName)
+	sb.WriteString("  const res = await fetch(BASE, {\n")
+	sb.WriteString("    method: 'POST',\n")
+	sb.WriteString("    headers: { 'Content-Type': 'application/json' },\n")
+	sb.WriteString("    body: JSON.stringify(data),\n")
+	sb.WriteString("  });\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function update%s(id: number, data: Partial<Create%sInput>): Promise<%s> {\n", structName, structName, structName)
+	sb.WriteString("  const res = await fetch(`${BASE}/${id}`, {\n")
+	sb.WriteString("    method: 'PUT',\n")
+	sb.WriteString("    headers: { 'Content-Type': 'application/json' },\n")
+	sb.WriteString("    body: JSON.stringify(data),\n")
+	sb.WriteString("  });\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("  return res.json();\n")
+	sb.WriteString("}\n\n")
+
+	fmt.Fprintf(&sb, "export async function delete%s(id: number): Promise<void> {\n", structName)
+	sb.WriteString("  const res = await fetch(`${BASE}/${id}`, { method: 'DELETE' });\n")
+	sb.WriteString("  if (!res.ok) throw new Error(await res.text());\n")
+	sb.WriteString("}\n")
+
+	return sb.String()
+}
+
+func GenerateReactPage(m Model) string {
+	singular := toSingular(m.Name)
+	structName := toPascalCase(singular)
+	pluralName := toPascalCase(m.Name)
+	componentName := structName + "Page"
+
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "import { useState, useEffect } from 'react';\n")
+	fmt.Fprintf(&sb, "import type { %s, Create%sInput } from '../types/%s';\n", structName, structName, singular)
+	fmt.Fprintf(&sb, "import { list%s, create%s, update%s, delete%s } from '../api/%s';\n\n", pluralName, structName, structName, structName, singular)
+
+	fmt.Fprintf(&sb, "const EMPTY_FORM: Create%sInput = {\n", structName)
+	for _, f := range m.Fields {
+		fmt.Fprintf(&sb, "  %s: %s,\n", f.Name, tsInputDefault(f.Type))
+	}
+	sb.WriteString("};\n\n")
+
+	fmt.Fprintf(&sb, "export default function %s() {\n", componentName)
+	fmt.Fprintf(&sb, "  const [items, setItems] = useState<%s[]>([]);\n", structName)
+	fmt.Fprintf(&sb, "  const [editing, setEditing] = useState<%s | null>(null);\n", structName)
+	fmt.Fprintf(&sb, "  const [form, setForm] = useState<Create%sInput>(EMPTY_FORM);\n", structName)
+	sb.WriteString("  const [showForm, setShowForm] = useState(false);\n\n")
+	sb.WriteString("  useEffect(() => { load(); }, []);\n\n")
+
+	fmt.Fprintf(&sb, "  async function load() {\n")
+	fmt.Fprintf(&sb, "    try { setItems(await list%s()); } catch (e) { console.error(e); }\n", pluralName)
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  function openCreate() {\n")
+	sb.WriteString("    setEditing(null); setForm(EMPTY_FORM); setShowForm(true);\n")
+	sb.WriteString("  }\n\n")
+
+	fmt.Fprintf(&sb, "  function openEdit(item: %s) {\n", structName)
+	sb.WriteString("    setEditing(item);\n")
+	sb.WriteString("    setForm({\n")
+	for _, f := range m.Fields {
+		if f.Required {
+			fmt.Fprintf(&sb, "      %s: item.%s,\n", f.Name, f.Name)
+		} else {
+			fmt.Fprintf(&sb, "      %s: item.%s ?? %s,\n", f.Name, f.Name, tsInputDefault(f.Type))
+		}
+	}
+	sb.WriteString("    });\n")
+	sb.WriteString("    setShowForm(true);\n")
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  async function handleSubmit(e: React.FormEvent) {\n")
+	sb.WriteString("    e.preventDefault();\n")
+	sb.WriteString("    try {\n")
+	fmt.Fprintf(&sb, "      if (editing) await update%s(editing.id, form);\n", structName)
+	fmt.Fprintf(&sb, "      else await create%s(form);\n", structName)
+	sb.WriteString("      setShowForm(false); load();\n")
+	sb.WriteString("    } catch (e) { console.error(e); }\n")
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  async function handleDelete(id: number) {\n")
+	sb.WriteString("    if (!confirm('Delete?')) return;\n")
+	fmt.Fprintf(&sb, "    try { await delete%s(id); load(); } catch (e) { console.error(e); }\n", structName)
+	sb.WriteString("  }\n\n")
+
+	sb.WriteString("  return (\n")
+	sb.WriteString("    <div>\n")
+	fmt.Fprintf(&sb, "      <h1>%s</h1>\n", m.Name)
+	sb.WriteString("      <button onClick={openCreate}>+ New</button>\n")
+	sb.WriteString("      {showForm && (\n")
+	sb.WriteString("        <form onSubmit={handleSubmit}>\n")
+	for _, f := range m.Fields {
+		inputType := tsInputType(f.Type)
+		if inputType == "checkbox" {
+			fmt.Fprintf(&sb, "          <label>%s <input type=\"checkbox\" checked={form.%s as boolean} onChange={e => setForm({...form, %s: e.target.checked})} /></label>\n", f.Name, f.Name, f.Name)
+		} else if inputType == "number" {
+			reqAttr := ""
+			if f.Required {
+				reqAttr = " required"
+			}
+			fmt.Fprintf(&sb, "          <label>%s <input type=\"number\" value={form.%s as number} onChange={e => setForm({...form, %s: Number(e.target.value)})}%s /></label>\n", f.Name, f.Name, f.Name, reqAttr)
+		} else {
+			reqAttr := ""
+			if f.Required {
+				reqAttr = " required"
+			}
+			fmt.Fprintf(&sb, "          <label>%s <input type=\"%s\" value={form.%s as string} onChange={e => setForm({...form, %s: e.target.value})}%s /></label>\n", f.Name, inputType, f.Name, f.Name, reqAttr)
+		}
+	}
+	sb.WriteString("          <button type=\"submit\">{editing ? 'Save' : 'Create'}</button>\n")
+	sb.WriteString("          <button type=\"button\" onClick={() => setShowForm(false)}>Cancel</button>\n")
+	sb.WriteString("        </form>\n")
+	sb.WriteString("      )}\n")
+	sb.WriteString("      <table>\n")
+	sb.WriteString("        <thead><tr><th>id</th>")
+	for _, f := range m.Fields {
+		fmt.Fprintf(&sb, "<th>%s</th>", f.Name)
+	}
+	sb.WriteString("<th></th></tr></thead>\n")
+	sb.WriteString("        <tbody>\n")
+	sb.WriteString("          {items.map(item => (\n")
+	sb.WriteString("            <tr key={item.id}>\n")
+	sb.WriteString("              <td>{item.id}</td>\n")
+	for _, f := range m.Fields {
+		if sqlTypeToTS(f.Type) == "boolean" {
+			fmt.Fprintf(&sb, "              <td>{item.%s ? 'yes' : 'no'}</td>\n", f.Name)
+		} else {
+			fmt.Fprintf(&sb, "              <td>{item.%s}</td>\n", f.Name)
+		}
+	}
+	sb.WriteString("              <td>\n")
+	sb.WriteString("                <button onClick={() => openEdit(item)}>Edit</button>\n")
+	sb.WriteString("                <button onClick={() => handleDelete(item.id)}>Del</button>\n")
+	sb.WriteString("              </td>\n")
+	sb.WriteString("            </tr>\n")
+	sb.WriteString("          ))}\n")
+	sb.WriteString("        </tbody>\n")
+	sb.WriteString("      </table>\n")
+	sb.WriteString("    </div>\n")
+	sb.WriteString("  );\n")
+	sb.WriteString("}\n")
 
 	return sb.String()
 }

--- a/sandbox/main_test.go
+++ b/sandbox/main_test.go
@@ -441,3 +441,233 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// ── React client generation tests ──────────────────────────────────────────
+
+var clientTestModel = Model{
+	Name: "students",
+	Fields: []Field{
+		{Name: "first_name", Type: "varchar(100)", Required: true},
+		{Name: "last_name", Type: "varchar(100)", Required: true},
+		{Name: "present", Type: "boolean", Default: false},
+	},
+}
+
+func TestGenerateReactTypes_Interface(t *testing.T) {
+	out := GenerateReactTypes(clientTestModel)
+
+	for _, want := range []string{
+		"export interface Student {",
+		"id: number;",
+		"first_name: string;",
+		"last_name: string;",
+		"present?: boolean;",
+		"created_at: string;",
+		"updated_at: string;",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in types output", want)
+		}
+	}
+}
+
+func TestGenerateReactTypes_InputType(t *testing.T) {
+	out := GenerateReactTypes(clientTestModel)
+
+	if !strings.Contains(out, "export type CreateStudentInput = {") {
+		t.Error("missing CreateStudentInput type")
+	}
+	// Required fields are non-optional in CreateInput
+	if !strings.Contains(out, "first_name: string;") {
+		t.Error("expected first_name as required string in CreateStudentInput")
+	}
+	// ID and timestamps are NOT in CreateInput
+	if strings.Contains(out, "id: number") && strings.Count(out, "id: number") > 1 {
+		t.Error("id should only appear in interface, not in CreateInput")
+	}
+}
+
+func TestGenerateReactAPI_Functions(t *testing.T) {
+	out := GenerateReactAPI(clientTestModel)
+
+	for _, want := range []string{
+		"export async function listStudents()",
+		"export async function getStudent(",
+		"export async function createStudent(",
+		"export async function updateStudent(",
+		"export async function deleteStudent(",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in API output", want)
+		}
+	}
+}
+
+func TestGenerateReactAPI_FetchMethods(t *testing.T) {
+	out := GenerateReactAPI(clientTestModel)
+
+	for _, want := range []string{
+		"method: 'POST'",
+		"method: 'PUT'",
+		"method: 'DELETE'",
+		"'Content-Type': 'application/json'",
+		"JSON.stringify(data)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in API output", want)
+		}
+	}
+}
+
+func TestGenerateReactAPI_BaseURL(t *testing.T) {
+	out := GenerateReactAPI(clientTestModel)
+	if !strings.Contains(out, "const BASE = '/students';") {
+		t.Error("expected BASE = '/students'")
+	}
+}
+
+func TestGenerateReactAPI_TypeImport(t *testing.T) {
+	out := GenerateReactAPI(clientTestModel)
+	if !strings.Contains(out, "import type { Student, CreateStudentInput } from '../types/student';") {
+		t.Error("expected type import from '../types/student'")
+	}
+}
+
+func TestGenerateReactPage_Component(t *testing.T) {
+	out := GenerateReactPage(clientTestModel)
+
+	for _, want := range []string{
+		"export default function StudentPage()",
+		"useState<Student[]>",
+		"useState<Student | null>",
+		"useState<CreateStudentInput>",
+		"useEffect",
+		"handleSubmit",
+		"handleDelete",
+		"openCreate",
+		"openEdit",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in page output", want)
+		}
+	}
+}
+
+func TestGenerateReactPage_Table(t *testing.T) {
+	out := GenerateReactPage(clientTestModel)
+
+	for _, want := range []string{
+		"<th>id</th>",
+		"<th>first_name</th>",
+		"<th>last_name</th>",
+		"item.id",
+		"item.first_name",
+		"{item.present ? 'yes' : 'no'}",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in page table", want)
+		}
+	}
+}
+
+func TestGenerateReactPage_Form(t *testing.T) {
+	out := GenerateReactPage(clientTestModel)
+
+	// Required text field has required attribute
+	if !strings.Contains(out, `type="text"`) {
+		t.Error("expected text input for varchar field")
+	}
+	if !strings.Contains(out, " required") {
+		t.Error("expected required attribute on required fields")
+	}
+	// Boolean field uses checkbox
+	if !strings.Contains(out, `type="checkbox"`) {
+		t.Error("expected checkbox input for boolean field")
+	}
+}
+
+func TestGenerateReactApp_Routes(t *testing.T) {
+	models := []Model{
+		{Name: "students", Fields: []Field{{Name: "name", Type: "text"}}},
+		{Name: "subjects", Fields: []Field{{Name: "name", Type: "text"}}},
+	}
+	out := GenerateReactApp(models)
+
+	for _, want := range []string{
+		"import StudentPage from './pages/StudentPage';",
+		"import SubjectPage from './pages/SubjectPage';",
+		`<Route path="/students" element={<StudentPage />} />`,
+		`<Route path="/subjects" element={<SubjectPage />} />`,
+		`<NavLink to="/students">`,
+		`<NavLink to="/subjects">`,
+		"BrowserRouter",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in App.tsx output", want)
+		}
+	}
+}
+
+func TestGenerateReactPackageJSON_Deps(t *testing.T) {
+	cfg := &Config{App: AppConfig{Name: "myapp", Port: 8080}}
+	out := GenerateReactPackageJSON(cfg)
+
+	for _, want := range []string{
+		`"react":`,
+		`"react-dom":`,
+		`"react-router-dom":`,
+		`"vite":`,
+		`"typescript":`,
+		`"myapp-client"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in package.json", want)
+		}
+	}
+}
+
+func TestGenerateReactViteConfig_Proxy(t *testing.T) {
+	cfg := &Config{
+		App:    AppConfig{Name: "myapp", Port: 3000},
+		Models: []Model{{Name: "students"}, {Name: "subjects"}},
+	}
+	out := GenerateReactViteConfig(cfg)
+
+	for _, want := range []string{
+		"proxy:",
+		"'/students': 'http://localhost:3000'",
+		"'/subjects': 'http://localhost:3000'",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in vite.config.ts", want)
+		}
+	}
+}
+
+func TestGenerateGORMModels_JSONTags(t *testing.T) {
+	models := []Model{
+		{Name: "students", Fields: []Field{
+			{Name: "first_name", Type: "varchar(100)", Required: true},
+			{Name: "score", Type: "int"},
+		}},
+	}
+	out := GenerateGORMModels(models, "models")
+
+	for _, want := range []string{
+		`json:"id"`,
+		`json:"created_at"`,
+		`json:"updated_at"`,
+		`json:"first_name"`,
+		`json:"score"`,
+		"type Base struct",
+		"\tBase\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in GORM models output", want)
+		}
+	}
+	// Must NOT embed gorm.Model directly
+	if strings.Contains(out, "gorm.Model\n") {
+		t.Error("should not embed gorm.Model; use Base struct instead")
+	}
+}

--- a/sandbox/models/models.go
+++ b/sandbox/models/models.go
@@ -7,29 +7,41 @@ import (
 )
 
 type Student struct {
-	gorm.Model
-	FirstName            string       `gorm:"column:first_name;size:100;not null"`
-	LastName             string       `gorm:"column:last_name;size:100;not null"`
-	Email                string       `gorm:"column:email;size:255;uniqueIndex"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	FirstName            string       `gorm:"column:first_name;size:100;not null" json:"first_name"`
+	LastName             string       `gorm:"column:last_name;size:100;not null" json:"last_name"`
+	Email                string       `gorm:"column:email;size:255;uniqueIndex" json:"email"`
 }
 
 type Subject struct {
-	gorm.Model
-	Name                 string       `gorm:"column:name;size:200;not null"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	Name                 string       `gorm:"column:name;size:200;not null" json:"name"`
 }
 
 type Lesson struct {
-	gorm.Model
-	Date                 time.Time    `gorm:"column:date;not null"`
-	SubjectID            int          `gorm:"column:subject_id"`
-	Subject              Subject      `gorm:"foreignKey:SubjectID"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	Date                 time.Time    `gorm:"column:date;not null" json:"date"`
+	SubjectID            int          `gorm:"column:subject_id" json:"subject_id"`
+	Subject              Subject      `gorm:"foreignKey:SubjectID" json:"-"`
 }
 
 type Attendance struct {
-	gorm.Model
-	LessonID             int          `gorm:"column:lesson_id"`
-	Lesson               Lesson       `gorm:"foreignKey:LessonID"`
-	StudentID            int          `gorm:"column:student_id"`
-	Student              Student      `gorm:"foreignKey:StudentID"`
-	Present              bool         `gorm:"column:present;default:FALSE"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	LessonID             int          `gorm:"column:lesson_id" json:"lesson_id"`
+	Lesson               Lesson       `gorm:"foreignKey:LessonID" json:"-"`
+	StudentID            int          `gorm:"column:student_id" json:"student_id"`
+	Student              Student      `gorm:"foreignKey:StudentID" json:"-"`
+	Present              bool         `gorm:"column:present;default:FALSE" json:"present"`
 }


### PR DESCRIPTION
## Summary

- Generate a full React + TypeScript frontend (`client/`) from the same YAML config used for the backend
- Update GORM model generation to use explicit fields with snake_case JSON tags so the server returns consistent snake_case JSON
- Add 12 new sandbox tests covering all client generation functions

## What changed

### New: `internal/generator/client.go`
Generates a complete React client per model:
- `src/types/{model}.ts` — TypeScript interfaces with snake_case fields (`id`, `first_name`, `created_at`, etc.)
- `src/api/{model}.ts` — fetch wrappers for all 5 CRUD operations (list, get, create, update, delete)
- `src/pages/{Model}Page.tsx` — CRUD page with a data table and inline create/edit form
- `src/App.tsx` — top-level app with BrowserRouter, NavLinks, and Routes per model
- Static files: `package.json`, `index.html`, `vite.config.ts`, `tsconfig.json`, `src/main.tsx`

### Updated: `internal/generator/generator.go`
`GenerateGORMModels` now generates explicit struct fields instead of embedding `gorm.Model`, with json tags on every field:
```go
type Student struct {
    ID        uint           `gorm:"primarykey" json:"id"`
    CreatedAt time.Time      `json:"created_at"`
    UpdatedAt time.Time      `json:"updated_at"`
    DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
    FirstName string         `gorm:"column:first_name;size:100;not null" json:"first_name"`
    ...
}
```
This ensures the Go server returns snake_case JSON that the generated TypeScript types expect.

### Updated: `cmd/build.go`
Adds a new `[10/10] Generating client` step that writes the full `client/` subtree to the output directory.

## Implementation details

- JSX generation uses `strings.Builder` + `fmt.Fprintf` (not Go `text/template`) to avoid `{{`/`}}` conflicts with JSX syntax
- Vite dev server is configured to proxy each model's route (e.g. `/students`) to the Go backend port
- Boolean fields render as `<input type="checkbox">`, date fields as `<input type="date">`, FK reference fields as `<input type="number">`
- Optional fields in the TypeScript interface use `?:`, but `CreateInput` types always have non-optional fields for clean form state management

## Generated output structure
```
dist/client/
├── package.json        # react, react-dom, react-router-dom, vite, typescript
├── index.html
├── vite.config.ts      # proxy /students, /subjects, ... → Go backend
├── tsconfig.json
└── src/
    ├── main.tsx
    ├── App.tsx
    ├── types/student.ts
    ├── api/student.ts
    └── pages/StudentPage.tsx
```

---
This PR was written using [Vibe Kanban](https://vibekanban.com)