### PR TITLE
Remove redundant schema.sql generation (Vibe Kanban)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -37,9 +37,6 @@ var buildCmd = &cobra.Command{
 			name string
 			fn   func() error
 		}{
-			{"Generating schema.sql", func() error {
-				return writeFile(filepath.Join(out, "schema.sql"), generator.GenerateSchema(cfg.Models))
-			}},
 			{"Generating migrations", func() error {
 				dir := filepath.Join(out, "migrations")
 				if err := os.MkdirAll(dir, 0755); err != nil {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -168,7 +168,7 @@ func ValidateConfig(cfg *Config) []error {
 	return errs
 }
 
-func GenerateSchema(models []Model) string {
+func GenerateMigrationUp(models []Model) string {
 	sorted := topoSort(models)
 	var sb strings.Builder
 	for i, m := range sorted {
@@ -178,10 +178,6 @@ func GenerateSchema(models []Model) string {
 		sb.WriteString(tableSQL(m))
 	}
 	return sb.String()
-}
-
-func GenerateMigrationUp(models []Model) string {
-	return GenerateSchema(models)
 }
 
 func GenerateMigrationDown(models []Model) string {


### PR DESCRIPTION
## What changed

- Removed `schema.sql` generation from the `gapp build` pipeline
- Removed the `GenerateSchema` function from `internal/generator/generator.go`
- Inlined the SQL generation logic directly into `GenerateMigrationUp`

## Why

`GenerateSchema` and `GenerateMigrationUp` produced **identical output** — both generated `CREATE TABLE` SQL statements in topological order. As a result, the generated `schema.sql` file was a byte-for-byte duplicate of `migrations/001_initial.up.sql`.

Since `dev.sh` applies the migration file directly (not `schema.sql`), and GORM AutoMigrate handles runtime schema enforcement, `schema.sql` provided no functional value and added unnecessary file bloat to generated projects.

## Implementation details

- `GenerateMigrationUp` now contains the logic previously in `GenerateSchema`, keeping the migration generation self-contained
- The `"Generating schema.sql"` step was removed from the build pipeline in `cmd/build.go`
- No tests were affected — `GenerateSchema` had no direct test coverage

---
This PR was written using [Vibe Kanban](https://vibekanban.com)