### PR TITLE
fix: correct GORM table names and tighten football-league schema (Vibe Kanban)

### DIFF
--- a/docs/examples/football-league.yaml
+++ b/docs/examples/football-league.yaml
@@ -75,6 +75,7 @@ models:
       - name: primary_position
         type: enum
         values: [gk, df, mf, fw]
+        required: true
 
   - name: coaches
     many_to_many: [clubs]
@@ -97,13 +98,16 @@ models:
         type: int
         references: clubs.id
         display_field: name
+        required: true
       - name: away_club_id
         type: int
         references: clubs.id
         display_field: name
+        required: true
       - name: stadium_id
         type: int
         references: stadiums.id
+        display_field: name
       - name: match_date
         type: timestamp
       - name: round_number
@@ -122,9 +126,12 @@ models:
       - name: match_id
         type: int
         references: matches.id
+        required: true
       - name: club_id
         type: int
         references: clubs.id
+        display_field: name
+        required: true
       - name: formation
         type: varchar(20)
 
@@ -133,10 +140,12 @@ models:
       - name: lineup_id
         type: int
         references: match_lineups.id
+        required: true
       - name: player_id
         type: int
         references: players.id
         display_field: first_name
+        required: true
       - name: position
         type: varchar(10)
       - name: is_starting
@@ -152,26 +161,36 @@ models:
       - name: match_id
         type: int
         references: matches.id
+        required: true
       - name: club_id
         type: int
         references: clubs.id
+        display_field: name
+        required: true
       - name: player_id
         type: int
         references: players.id
+        display_field: first_name
+        required: true
       - name: minute
         type: int
       - name: event_type
         type: enum
         values: [goal, assist, yellow_card, red_card, substitution]
+        required: true
 
   - name: standings
     fields:
       - name: season_id
         type: int
         references: seasons.id
+        display_field: name
+        required: true
       - name: club_id
         type: int
         references: clubs.id
+        display_field: name
+        required: true
       - name: played
         type: int
       - name: wins
@@ -192,12 +211,16 @@ models:
       - name: player_id
         type: int
         references: players.id
+        display_field: first_name
+        required: true
       - name: from_club_id
         type: int
         references: clubs.id
+        display_field: name
       - name: to_club_id
         type: int
         references: clubs.id
+        display_field: name
       - name: transfer_date
         type: date
       - name: fee
@@ -205,15 +228,20 @@ models:
       - name: season_id
         type: int
         references: seasons.id
+        display_field: name
 
   - name: injuries
     fields:
       - name: player_id
         type: int
         references: players.id
+        display_field: first_name
+        required: true
       - name: club_id
         type: int
         references: clubs.id
+        display_field: name
+        required: true
       - name: injury_type
         type: varchar(200)
       - name: start_date

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -514,6 +514,7 @@ type gormM2MField struct {
 
 type gormModelData struct {
 	StructName string
+	TableName  string
 	Fields     []gormFieldData
 	M2MFields  []gormM2MField
 }
@@ -572,7 +573,7 @@ func GenerateGORMModels(models []Model, pkgName string) string {
 				})
 			}
 		}
-		modelData = append(modelData, gormModelData{StructName: structName, Fields: fields, M2MFields: m2mFields})
+		modelData = append(modelData, gormModelData{StructName: structName, TableName: m.Name, Fields: fields, M2MFields: m2mFields})
 	}
 
 	data := struct {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -531,6 +531,22 @@ func TestGenerateGORMModels_AssociationJSONTag(t *testing.T) {
 	}
 }
 
+func TestGenerateGORMModels_TableName(t *testing.T) {
+	// GORM pluralises "Stadium" → "stadia" (Latin); TableName() must override to "stadiums"
+	models := []Model{
+		{Name: "stadiums", Fields: []Field{{Name: "name", Type: "varchar(200)", Required: true}}},
+		{Name: "leagues", Fields: []Field{{Name: "name", Type: "varchar(200)", Required: true}}},
+	}
+	out := GenerateGORMModels(models, "models")
+
+	if !strings.Contains(out, `func (Stadium) TableName() string { return "stadiums" }`) {
+		t.Errorf("expected TableName() returning \"stadiums\" for Stadium struct:\n%s", out)
+	}
+	if !strings.Contains(out, `func (League) TableName() string { return "leagues" }`) {
+		t.Errorf("expected TableName() returning \"leagues\" for League struct:\n%s", out)
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/generator/templates/gorm_models.go.tmpl
+++ b/internal/generator/templates/gorm_models.go.tmpl
@@ -19,4 +19,6 @@ type {{.StructName}} struct {
 {{if .AssocField}}	{{printf "%-20s %-12s" .AssocField .AssocType}}`{{.AssocTags}}`
 {{end}}{{end}}{{range .M2MFields}}	{{printf "%-20s %-12s" .FieldName .SliceType}}`{{.Tags}}`
 {{end}}}
+
+func ({{.StructName}}) TableName() string { return "{{.TableName}}" }
 {{end}}


### PR DESCRIPTION
## What changed

### 1. GORM `TableName()` to prevent wrong pluralization

GORM's built-in `inflection` library applies Latin/irregular plurals when deriving table names from struct names — `Stadium` → `stadia`, `Person` → `people`, etc. — instead of using the table names defined in the YAML schema.

Each generated GORM model now includes an explicit `TableName()` method:

```go
func (Stadium) TableName() string { return "stadiums" }
```

**Files changed:** `gorm_models.go.tmpl`, `generator.go` (added `TableName` field to `gormModelData`), `generator_test.go`

### 2. `football-league.yaml` schema hardening

Inspected the example schema and applied the following corrections:

- **`required: true`** added to logically mandatory FK fields:
  - `matches`: `home_club_id`, `away_club_id`
  - `match_lineups`: `match_id`, `club_id`
  - `lineup_players`: `lineup_id`, `player_id`
  - `match_events`: `match_id`, `club_id`, `player_id`, `event_type`
  - `standings`: `season_id`, `club_id`
  - `transfers`: `player_id`
  - `injuries`: `player_id`, `club_id`
  - `players`: `primary_position`
- **`display_field`** added where it was missing: `matches.stadium_id`, `match_events.club_id`/`player_id`, `standings`, `transfers`, `injuries`
- `transfers.from_club_id` and `to_club_id` remain optional — a transfer may involve a free agent with no source/destination club

## Why

The `TableName()` bug was discovered after auto-migration created a `stadia` table instead of `stadiums`, breaking FK references from other tables. Required-field and display-field gaps in the schema were identified during a schema review and would have caused nullable FK inserts and missing dropdown labels in the generated UI.

## Implementation notes

- Required FK fields now generate as non-pointer Go types (`int`) and non-nullable TypeScript types (`number`), while optional FK fields use `*int` / `number | null` (from the previous fix in PR #52)
- A dedicated test `TestGenerateGORMModels_TableName` verifies that `Stadium` → `"stadiums"` and `League` → `"leagues"`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)