### PR TITLE
Fix docker-compose template: correct DB_PORT and templated credentials (Vibe Kanban)

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -617,13 +617,17 @@ func GenerateMain(cfg *Config, appImport string) (string, error) {
 
 func GenerateDockerCompose(cfg *Config) (string, error) {
 	data := struct {
-		Port   int
-		DBPort int
-		DBName string
+		Port       int
+		DBPort     int
+		DBName     string
+		DBUser     string
+		DBPassword string
 	}{
-		Port:   cfg.App.Port,
-		DBPort: cfg.Database.Port,
-		DBName: cfg.Database.Name,
+		Port:       cfg.App.Port,
+		DBPort:     cfg.Database.Port,
+		DBName:     cfg.Database.Name,
+		DBUser:     cfg.Database.User,
+		DBPassword: cfg.Database.Password,
 	}
 	var buf strings.Builder
 	if err := template.Must(template.New("docker-compose").Parse(dockerComposeTmpl)).Execute(&buf, data); err != nil {

--- a/internal/generator/templates/docker-compose.yml.tmpl
+++ b/internal/generator/templates/docker-compose.yml.tmpl
@@ -5,29 +5,32 @@ services:
       - "{{.Port}}:{{.Port}}"
     environment:
       DB_HOST: postgres
-      DB_PORT: {{.DBPort}}
+      DB_PORT: 5432
       DB_NAME: {{.DBName}}
-      DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-secret}
+      DB_USER: {{.DBUser}}
+      DB_PASSWORD: {{.DBPassword}}
+      DB_SSLMODE: disable
     depends_on:
       postgres:
         condition: service_healthy
+    restart: unless-stopped
 
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: ${DB_USER:-postgres}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-secret}
+      POSTGRES_USER: {{.DBUser}}
+      POSTGRES_PASSWORD: {{.DBPassword}}
       POSTGRES_DB: {{.DBName}}
     ports:
       - "{{.DBPort}}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d {{.DBName}}"]
+      test: ["CMD-SHELL", "pg_isready -U {{.DBUser}} -d {{.DBName}}"]
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## What changed

- **Fixed `DB_PORT` bug**: The app service was using `{{.DBPort}}` (the host-mapped port) as `DB_PORT`. Within the Docker network, the app connects to the `postgres` service on its *internal* container port, which is always `5432`. If a user configured a non-default `DBPort` (e.g. `5433`), the app would fail to connect even though the container was healthy.
- **Templated credentials**: Replaced shell variable expansions (`${DB_USER:-postgres}`, `${DB_PASSWORD:-secret}`) with proper Go template variables (`{{.DBUser}}`, `{{.DBPassword}}`). The `Config` struct already holds these values and other templates (`.env.tmpl`, `dev.sh.tmpl`) use them consistently — docker-compose was the odd one out.
- **Added `DB_SSLMODE: disable`** to the app service environment, consistent with what `.env.tmpl` generates.
- **Added `restart: unless-stopped`** to both `app` and `postgres` services for reliable recovery after crashes or host reboots.
- **Updated `GenerateDockerCompose`** in `generator.go` to pass `DBUser` and `DBPassword` from `cfg.Database` into the template data struct.

## Why

The previous template had a correctness bug (`DB_PORT` inside Docker should always be `5432`) and an inconsistency where credentials were handled differently from every other generated file. This caused potential connection failures and made the generated docker-compose unreliable when non-default database ports were configured.

## Implementation details

- `DB_PORT: 5432` is now hardcoded in the template since it represents the internal Postgres port, which never changes regardless of the host-side port mapping.
- All other dynamic values (`DBUser`, `DBPassword`) flow through the Go template engine, keeping the approach consistent across all generated files.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)