### PR TITLE
feat: add day/night theme toggle and localStorage persistence (Vibe Kanban)

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useId } from 'react'
+import { useState, useCallback, useEffect, useId } from 'react'
 import { generateYaml, generateYamlHighlighted } from './yamlGenerator.js'
 import AppSection from './components/AppSection.jsx'
 import DatabaseSection from './components/DatabaseSection.jsx'
@@ -40,8 +40,22 @@ const INITIAL = {
 
 export { DEFAULT_FIELD, DEFAULT_MODEL }
 
+const STORAGE_KEY = 'gaplicator_config'
+
+function loadConfig() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw)
+  } catch (_) {}
+  return null
+}
+
 export default function App() {
-  const [config, setConfig] = useState(INITIAL)
+  const [config, setConfig] = useState(() => loadConfig() || INITIAL)
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(config)) } catch (_) {}
+  }, [config])
 
   const setApp = useCallback(patch =>
     setConfig(c => ({ ...c, app: { ...c.app, ...patch } })), [])

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5,6 +5,7 @@ import DatabaseSection from './components/DatabaseSection.jsx'
 import AuthSection from './components/AuthSection.jsx'
 import ModelsSection from './components/ModelsSection.jsx'
 import YamlPreview from './components/YamlPreview.jsx'
+import ThemeToggle from './components/ThemeToggle.jsx'
 
 let _id = 0
 export function uid() { return ++_id }
@@ -66,6 +67,7 @@ export default function App() {
         </div>
         <div className="app-header-sep" />
         <div className="app-header-sub">Schema Generator</div>
+        <ThemeToggle />
       </header>
 
       <div className="app-body">

--- a/web/src/components/ThemeToggle.jsx
+++ b/web/src/components/ThemeToggle.jsx
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react'
+import { Sun, Moon } from './icons.jsx'
+
+function getInitialTheme() {
+  try {
+    const stored = localStorage.getItem('theme')
+    if (stored === 'light' || stored === 'dark') return stored
+  } catch (_) {}
+  return 'dark'
+}
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState(getInitialTheme)
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    try { localStorage.setItem('theme', theme) } catch (_) {}
+  }, [theme])
+
+  const isLight = theme === 'light'
+
+  return (
+    <button
+      className="btn-icon theme-toggle"
+      onClick={() => setTheme(isLight ? 'dark' : 'light')}
+      title={isLight ? 'Switch to dark mode' : 'Switch to light mode'}
+    >
+      {isLight ? <Moon /> : <Sun />}
+    </button>
+  )
+}

--- a/web/src/components/icons.jsx
+++ b/web/src/components/icons.jsx
@@ -38,3 +38,20 @@ export function Check({ size = 13 }) {
     </svg>
   )
 }
+
+export function Sun({ size = 15 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 20 20" fill="none">
+      <circle cx="10" cy="10" r="4" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.22 4.22l1.42 1.42M14.36 14.36l1.42 1.42M4.22 15.78l1.42-1.42M14.36 5.64l1.42-1.42" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function Moon({ size = 15 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 20 20" fill="none">
+      <path d="M17 12A7 7 0 019 4a7 7 0 100 12 7 7 0 008-4z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -27,6 +27,27 @@
   --shadow: 0 2px 12px rgba(0,0,0,0.35);
 }
 
+[data-theme="light"] {
+  --bg: #f4f6fb;
+  --bg-card: #ffffff;
+  --bg-input: #eef0f8;
+  --bg-hover: #e6e9f5;
+  --border: #d8dcea;
+  --border-focus: #4f6ef7;
+  --text: #1a1d2e;
+  --text-muted: #5a6380;
+  --text-dim: #9aa0b4;
+  --accent: #4f6ef7;
+  --accent-hover: #3d5ce8;
+  --accent-light: rgba(79, 110, 247, 0.1);
+  --danger: #e04545;
+  --danger-hover: #c73a3a;
+  --danger-light: rgba(224, 69, 69, 0.09);
+  --success: #2ea866;
+  --warning: #c87a10;
+  --shadow: 0 2px 12px rgba(0,0,0,0.08);
+}
+
 html, body {
   margin: 0;
   padding: 0;
@@ -81,6 +102,15 @@ html, body {
 .app-header-sub {
   color: var(--text-muted);
   font-size: 13px;
+}
+
+.theme-toggle {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+
+.theme-toggle:hover {
+  color: var(--text);
 }
 
 .app-body {


### PR DESCRIPTION
## What changed

### Day/Night theme toggle
- Added a **Sun/Moon toggle button** to the app header (right-aligned) that switches between dark and light modes
- Added `[data-theme="light"]` CSS variable overrides in `index.css` with a full light palette (backgrounds, borders, text, accents, states)
- Created `ThemeToggle.jsx` component that reads/writes `localStorage` and sets `data-theme` on `<html>`
- Added `Sun` and `Moon` SVG icons to `icons.jsx`

### Schema persistence
- The schema config (all sections: app, database, auth, models) is now **saved to `localStorage`** on every change and **restored on page load**
- Falls back to the default initial state if nothing is stored yet

## Why

- **Theme**: users work with the tool for extended periods; a light mode option reduces eye strain in bright environments and respects personal preference
- **Persistence**: losing the entire schema on a page refresh was a significant UX pain point — the config now survives reloads, tab restores, and browser restarts

## Implementation details

- Theme is stored under the key `theme` in `localStorage`; schema config under `gaplicator_config`
- Both reads and writes are wrapped in try/catch to handle private browsing or storage quota errors gracefully
- The toggle shows the icon for the mode you'll *switch to* (Sun → switch to light, Moon → switch to dark), following common UI convention
- Theme is applied via `data-theme` attribute on `<html>` so CSS variables cascade correctly to all elements

---

This PR was written using [Vibe Kanban](https://vibekanban.com)