### PR TITLE
feat: add projects system and simple schema generation (Vibe Kanban)

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,16 +1,21 @@
-import { useState, useCallback, useEffect, useId } from 'react'
-import { generateYaml, generateYamlHighlighted } from './yamlGenerator.js'
+import { useState, useCallback, useEffect } from 'react'
+import {
+  generateYaml, generateYamlHighlighted,
+  generateSimpleYaml, generateSimpleYamlHighlighted,
+} from './yamlGenerator.js'
 import AppSection from './components/AppSection.jsx'
 import DatabaseSection from './components/DatabaseSection.jsx'
 import AuthSection from './components/AuthSection.jsx'
 import ModelsSection from './components/ModelsSection.jsx'
 import YamlPreview from './components/YamlPreview.jsx'
 import ThemeToggle from './components/ThemeToggle.jsx'
+import ProjectsView from './components/ProjectsView.jsx'
+import { loadProjects, saveProjects, createProject } from './projectStorage.js'
 
 let _id = 0
 export function uid() { return ++_id }
 
-const DEFAULT_FIELD = () => ({
+export const DEFAULT_FIELD = () => ({
   _id: uid(),
   name: '',
   type: 'varchar(255)',
@@ -24,63 +29,109 @@ const DEFAULT_FIELD = () => ({
   values: [],
 })
 
-const DEFAULT_MODEL = () => ({
+export const DEFAULT_MODEL = () => ({
   _id: uid(),
   name: '',
   many_to_many: [],
   fields: [DEFAULT_FIELD()],
 })
 
-const INITIAL = {
-  app: { name: 'my-app', port: 8080 },
-  database: { driver: 'postgres', host: 'localhost', port: 5432, name: 'my_db', user: 'postgres', password: 'secret' },
-  auth: { enabled: false, model: '' },
-  models: [],
-}
-
-export { DEFAULT_FIELD, DEFAULT_MODEL }
-
-const STORAGE_KEY = 'gaplicator_config'
-
-function loadConfig() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (raw) return JSON.parse(raw)
-  } catch (_) {}
-  return null
-}
-
 export default function App() {
-  const [config, setConfig] = useState(() => loadConfig() || INITIAL)
+  const [projects, setProjects] = useState(loadProjects)
+  const [activeProjectId, setActiveProjectId] = useState(null)
 
+  // Persist projects whenever they change
   useEffect(() => {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(config)) } catch (_) {}
-  }, [config])
+    saveProjects(projects)
+  }, [projects])
+
+  const activeProject = projects.find(p => p.id === activeProjectId) ?? null
+
+  // ── Project management ──────────────────────────────────────────────────────
+
+  const handleCreate = useCallback((name, type) => {
+    const project = createProject(name, type)
+    setProjects(ps => [...ps, project])
+    setActiveProjectId(project.id)
+  }, [])
+
+  const handleOpen = useCallback((id) => {
+    setActiveProjectId(id)
+  }, [])
+
+  const handleDelete = useCallback((id) => {
+    setProjects(ps => ps.filter(p => p.id !== id))
+    if (activeProjectId === id) setActiveProjectId(null)
+  }, [activeProjectId])
+
+  const handleBack = useCallback(() => {
+    setActiveProjectId(null)
+  }, [])
+
+  // ── Config updater for active project ───────────────────────────────────────
+
+  const updateConfig = useCallback((updater) => {
+    setProjects(ps => ps.map(p => {
+      if (p.id !== activeProjectId) return p
+      const newConfig = typeof updater === 'function' ? updater(p.config) : updater
+      return { ...p, config: newConfig, updatedAt: new Date().toISOString() }
+    }))
+  }, [activeProjectId])
 
   const setApp = useCallback(patch =>
-    setConfig(c => ({ ...c, app: { ...c.app, ...patch } })), [])
+    updateConfig(c => ({ ...c, app: { ...c.app, ...patch } })), [updateConfig])
 
   const setDatabase = useCallback(patch =>
-    setConfig(c => ({ ...c, database: { ...c.database, ...patch } })), [])
+    updateConfig(c => ({ ...c, database: { ...c.database, ...patch } })), [updateConfig])
 
   const setAuth = useCallback(patch =>
-    setConfig(c => ({ ...c, auth: { ...c.auth, ...patch } })), [])
+    updateConfig(c => ({ ...c, auth: { ...c.auth, ...patch } })), [updateConfig])
 
   const setModels = useCallback(updater =>
-    setConfig(c => ({ ...c, models: typeof updater === 'function' ? updater(c.models) : updater })), [])
+    updateConfig(c => ({ ...c, models: typeof updater === 'function' ? updater(c.models) : updater })),
+    [updateConfig])
 
-  const yaml = generateYaml(config)
-  const highlighted = generateYamlHighlighted(config)
+  // ── Projects view ───────────────────────────────────────────────────────────
+
+  if (!activeProject) {
+    return (
+      <ProjectsView
+        projects={projects}
+        onOpen={handleOpen}
+        onCreate={handleCreate}
+        onDelete={handleDelete}
+      />
+    )
+  }
+
+  // ── Editor view ─────────────────────────────────────────────────────────────
+
+  const config = activeProject.config
+  const schemaType = activeProject.type
+
+  const fullYaml = generateYaml(config)
+  const fullHighlighted = generateYamlHighlighted(config)
+  const simpleYaml = generateSimpleYaml(config)
+  const simpleHighlighted = generateSimpleYamlHighlighted(config)
+
   const modelNames = config.models.map(m => m.name).filter(Boolean)
 
   return (
     <div className="app-layout">
       <header className="app-header">
+        <button className="btn-back" onClick={handleBack} title="Back to projects">
+          ←
+        </button>
         <div className="app-header-logo">
           Gaplic<span>ator</span>
         </div>
         <div className="app-header-sep" />
-        <div className="app-header-sub">Schema Generator</div>
+        <div className="app-header-project">
+          <span className="app-header-project-name">{activeProject.name}</span>
+          <span className={`project-type-badge ${schemaType}`}>
+            {schemaType === 'simple' ? 'Simple' : 'Full'}
+          </span>
+        </div>
         <ThemeToggle />
       </header>
 
@@ -96,7 +147,13 @@ export default function App() {
           />
         </div>
 
-        <YamlPreview yaml={yaml} highlighted={highlighted} />
+        <YamlPreview
+          fullYaml={fullYaml}
+          fullHighlighted={fullHighlighted}
+          simpleYaml={simpleYaml}
+          simpleHighlighted={simpleHighlighted}
+          defaultTab={schemaType}
+        />
       </div>
     </div>
   )

--- a/web/src/components/ProjectsView.jsx
+++ b/web/src/components/ProjectsView.jsx
@@ -1,0 +1,163 @@
+import { useState } from 'react'
+import ThemeToggle from './ThemeToggle.jsx'
+import { relativeTime } from '../projectStorage.js'
+
+function NewProjectForm({ onSubmit, onCancel }) {
+  const [name, setName] = useState('')
+  const [type, setType] = useState('full')
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onSubmit(trimmed, type)
+  }
+
+  return (
+    <div className="new-project-modal-overlay" onClick={onCancel}>
+      <div className="new-project-modal" onClick={e => e.stopPropagation()}>
+        <div className="new-project-modal-title">New Project</div>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group" style={{ marginBottom: 14 }}>
+            <label className="form-label">Project Name</label>
+            <input
+              className="form-input"
+              placeholder="my-app"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div className="form-group" style={{ marginBottom: 20 }}>
+            <label className="form-label">Schema Type</label>
+            <div className="schema-type-picker">
+              <button
+                type="button"
+                className={`schema-type-btn ${type === 'simple' ? 'active' : ''}`}
+                onClick={() => setType('simple')}
+              >
+                <span className="schema-type-icon">⚡</span>
+                <span className="schema-type-label">Simple</span>
+                <span className="schema-type-desc">Compact YAML, auto-inferred</span>
+              </button>
+              <button
+                type="button"
+                className={`schema-type-btn ${type === 'full' ? 'active' : ''}`}
+                onClick={() => setType('full')}
+              >
+                <span className="schema-type-icon">⚙</span>
+                <span className="schema-type-label">Full</span>
+                <span className="schema-type-desc">Complete control over fields</span>
+              </button>
+            </div>
+          </div>
+
+          <div className="new-project-modal-actions">
+            <button type="button" className="btn btn-ghost" onClick={onCancel}>Cancel</button>
+            <button type="submit" className="btn btn-primary" disabled={!name.trim()}>
+              Create Project
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function ProjectCard({ project, onOpen, onDelete }) {
+  const modelCount = project.config?.models?.length ?? 0
+
+  function handleDelete(e) {
+    e.stopPropagation()
+    if (confirm(`Delete "${project.name}"? This cannot be undone.`)) {
+      onDelete(project.id)
+    }
+  }
+
+  return (
+    <div className="project-card" onClick={() => onOpen(project.id)}>
+      <div className="project-card-header">
+        <span className="project-card-name">{project.name}</span>
+        <span className={`project-type-badge ${project.type}`}>
+          {project.type === 'simple' ? 'Simple' : 'Full'}
+        </span>
+      </div>
+      <div className="project-card-meta">
+        <span>{modelCount} {modelCount === 1 ? 'model' : 'models'}</span>
+        <span className="project-card-dot">·</span>
+        <span>{relativeTime(project.updatedAt)}</span>
+      </div>
+      <div className="project-card-footer">
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={e => { e.stopPropagation(); onOpen(project.id) }}
+        >
+          Open
+        </button>
+        <button
+          className="btn btn-danger btn-sm"
+          onClick={handleDelete}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function ProjectsView({ projects, onOpen, onCreate, onDelete }) {
+  const [showForm, setShowForm] = useState(false)
+
+  function handleCreate(name, type) {
+    onCreate(name, type)
+    setShowForm(false)
+  }
+
+  return (
+    <div className="app-layout">
+      <header className="app-header">
+        <div className="app-header-logo">
+          Gaplic<span>ator</span>
+        </div>
+        <div className="app-header-sep" />
+        <div className="app-header-sub">Schema Generator</div>
+        <ThemeToggle />
+      </header>
+
+      <div className="projects-page">
+        <div className="projects-page-header">
+          <h1 className="projects-page-title">Projects</h1>
+          <button className="btn btn-primary" onClick={() => setShowForm(true)}>
+            + New Project
+          </button>
+        </div>
+
+        {projects.length === 0 ? (
+          <div className="empty-state" style={{ marginTop: 60 }}>
+            <div className="empty-state-icon">📂</div>
+            <div>No projects yet. Create one to get started.</div>
+          </div>
+        ) : (
+          <div className="projects-grid">
+            {projects.map(p => (
+              <ProjectCard
+                key={p.id}
+                project={p}
+                onOpen={onOpen}
+                onDelete={onDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showForm && (
+        <NewProjectForm
+          onSubmit={handleCreate}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/components/YamlPreview.jsx
+++ b/web/src/components/YamlPreview.jsx
@@ -1,8 +1,12 @@
 import { useState, useCallback } from 'react'
 import { Copy, Check } from './icons.jsx'
 
-export default function YamlPreview({ yaml, highlighted }) {
+export default function YamlPreview({ fullYaml, fullHighlighted, simpleYaml, simpleHighlighted, defaultTab }) {
+  const [tab, setTab] = useState(defaultTab || 'full')
   const [copied, setCopied] = useState(false)
+
+  const yaml = tab === 'simple' ? simpleYaml : fullYaml
+  const highlighted = tab === 'simple' ? simpleHighlighted : fullHighlighted
 
   const handleCopy = useCallback(async () => {
     try {
@@ -10,7 +14,6 @@ export default function YamlPreview({ yaml, highlighted }) {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {
-      // Fallback for non-https
       const el = document.createElement('textarea')
       el.value = yaml
       el.style.position = 'fixed'
@@ -27,7 +30,20 @@ export default function YamlPreview({ yaml, highlighted }) {
   return (
     <div className="preview-panel">
       <div className="preview-header">
-        <span className="preview-title">YAML Preview</span>
+        <div className="preview-tabs">
+          <button
+            className={`preview-tab ${tab === 'simple' ? 'active' : ''}`}
+            onClick={() => setTab('simple')}
+          >
+            Simple
+          </button>
+          <button
+            className={`preview-tab ${tab === 'full' ? 'active' : ''}`}
+            onClick={() => setTab('full')}
+          >
+            Full
+          </button>
+        </div>
         <button
           className={`btn-copy ${copied ? 'copied' : ''}`}
           onClick={handleCopy}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -721,8 +721,257 @@ html, body {
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
 
+/* ---------- Back button ---------- */
+.btn-back {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  line-height: 1;
+  transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.btn-back:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+/* ---------- Header project info ---------- */
+.app-header-project {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-header-project-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* ---------- Project type badge ---------- */
+.project-type-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 2px 7px;
+  border-radius: 10px;
+}
+
+.project-type-badge.simple {
+  background: rgba(69, 200, 126, 0.12);
+  color: var(--success);
+  border: 1px solid rgba(69, 200, 126, 0.25);
+}
+
+.project-type-badge.full {
+  background: var(--accent-light);
+  color: var(--accent);
+  border: 1px solid rgba(79, 110, 247, 0.25);
+}
+
+/* ---------- Projects page ---------- */
+.projects-page {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px;
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.projects-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.projects-page-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* ---------- Projects grid ---------- */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.project-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.project-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-light);
+}
+
+.project-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.project-card-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  word-break: break-word;
+  flex: 1;
+}
+
+.project-card-meta {
+  font-size: 12px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.project-card-dot {
+  color: var(--border);
+}
+
+.project-card-footer {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* ---------- New project modal ---------- */
+.new-project-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  backdrop-filter: blur(2px);
+}
+
+.new-project-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  width: 380px;
+  box-shadow: var(--shadow);
+}
+
+.new-project-modal-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 20px;
+}
+
+.new-project-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* ---------- Schema type picker ---------- */
+.schema-type-picker {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.schema-type-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  padding: 12px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  text-align: left;
+  font-family: inherit;
+}
+
+.schema-type-btn:hover {
+  border-color: var(--border-focus);
+}
+
+.schema-type-btn.active {
+  border-color: var(--accent);
+  background: var(--accent-light);
+}
+
+.schema-type-icon {
+  font-size: 18px;
+  margin-bottom: 4px;
+}
+
+.schema-type-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.schema-type-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ---------- YAML Preview tabs ---------- */
+.preview-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+}
+
+.preview-tab {
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+  font-family: inherit;
+}
+
+.preview-tab:hover {
+  color: var(--text);
+}
+
+.preview-tab.active {
+  background: var(--bg-card);
+  color: var(--text);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 900px) {
   .app-body { flex-direction: column; }
   .preview-panel { width: 100%; height: 300px; border-left: none; border-top: 1px solid var(--border); }
+  .projects-page { padding: 20px; }
+  .projects-grid { grid-template-columns: 1fr; }
 }

--- a/web/src/projectStorage.js
+++ b/web/src/projectStorage.js
@@ -1,0 +1,76 @@
+const PROJECTS_KEY = 'gaplicator_projects'
+const OLD_CONFIG_KEY = 'gaplicator_config'
+
+function makeId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7)
+}
+
+function defaultConfig(slug) {
+  return {
+    app: { name: slug || 'my-app', port: 8080 },
+    database: { driver: 'postgres', host: 'localhost', port: 5432, name: (slug || 'my_app').replace(/-/g, '_'), user: 'postgres', password: 'secret' },
+    auth: { enabled: false, model: '' },
+    models: [],
+  }
+}
+
+export function loadProjects() {
+  try {
+    const raw = localStorage.getItem(PROJECTS_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed
+    }
+  } catch (_) {}
+
+  // Migrate from old single-config storage
+  try {
+    const oldRaw = localStorage.getItem(OLD_CONFIG_KEY)
+    if (oldRaw) {
+      const oldConfig = JSON.parse(oldRaw)
+      const migrated = [{
+        id: makeId(),
+        name: oldConfig.app?.name || 'My Project',
+        type: 'full',
+        config: oldConfig,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }]
+      saveProjects(migrated)
+      return migrated
+    }
+  } catch (_) {}
+
+  return []
+}
+
+export function saveProjects(projects) {
+  try {
+    localStorage.setItem(PROJECTS_KEY, JSON.stringify(projects))
+  } catch (_) {}
+}
+
+export function createProject(name, type) {
+  const slug = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-_]/g, '') || 'my-app'
+  return {
+    id: makeId(),
+    name,
+    type, // 'simple' | 'full'
+    config: defaultConfig(slug),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+export function relativeTime(isoStr) {
+  const diff = Date.now() - new Date(isoStr).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days === 1) return 'yesterday'
+  if (days < 30) return `${days}d ago`
+  return new Date(isoStr).toLocaleDateString()
+}

--- a/web/src/yamlGenerator.js
+++ b/web/src/yamlGenerator.js
@@ -173,3 +173,74 @@ export function generateYaml(config) {
 export function generateYamlHighlighted(config) {
   return highlightYaml(generateYaml(config))
 }
+
+// ── Simple schema generation ─────────────────────────────────────────────────
+
+function toSimpleType(field) {
+  // FK reference → rel
+  if (field.references) return 'rel'
+  const t = (field.type || '').toLowerCase()
+  // enum with values → enum("a","b","c")
+  if (t === 'enum' && field.values && field.values.filter(Boolean).length > 0) {
+    const vals = field.values.filter(Boolean).map(v => `"${v}"`).join(',')
+    return `enum(${vals})`
+  }
+  // varchar(N) → string
+  if (t.startsWith('varchar')) return 'string'
+  return t || 'string'
+}
+
+function toSimpleFieldName(field) {
+  // Strip _id suffix from FK fields for cleaner simple schema output
+  if (field.references && field.name.endsWith('_id')) {
+    return field.name.slice(0, -3)
+  }
+  return field.name
+}
+
+export function generateSimpleYaml(config) {
+  const models = config.models.filter(m => m.name)
+  if (models.length === 0) return '# No models defined\n'
+
+  const lines = []
+  lines.push('models:')
+
+  for (const model of models) {
+    lines.push(`    ${model.name}:`)
+    const fields = model.fields.filter(f => f.name && f.type)
+    for (const field of fields) {
+      const fname = toSimpleFieldName(field)
+      const ftype = toSimpleType(field)
+      lines.push(`        ${fname}: ${ftype}`)
+    }
+  }
+
+  // M2M section — deduplicate by sorting pair
+  const seen = new Set()
+  const m2mEntries = []
+
+  for (const model of models) {
+    const m2m = (model.many_to_many || []).filter(Boolean)
+    for (const other of m2m) {
+      const key = [model.name, other].sort().join('|')
+      if (seen.has(key)) continue
+      seen.add(key)
+      m2mEntries.push({ name: `${model.name}_has_${other}`, a: model.name, b: other })
+    }
+  }
+
+  if (m2mEntries.length > 0) {
+    lines.push('m2m:')
+    for (const entry of m2mEntries) {
+      lines.push(`    ${entry.name}:`)
+      lines.push(`        ${entry.a}: rel`)
+      lines.push(`        ${entry.b}: rel`)
+    }
+  }
+
+  return lines.join('\n') + '\n'
+}
+
+export function generateSimpleYamlHighlighted(config) {
+  return highlightYaml(generateSimpleYaml(config))
+}


### PR DESCRIPTION
## Summary

- Introduce a **Projects** system backed by `localStorage`: create, open, and delete named projects, each with a schema type (`simple` or `full`) and an auto-saved config
- Add **Simple Schema generation** (`generateSimpleYaml`) that produces compact YAML compatible with the `tools/simpleschema` CLI tool
- Add **Simple / Full tab switcher** in the YAML Preview panel so users can always see either format regardless of project type

## What changed

### `web/src/projectStorage.js` (new)
- `loadProjects()` — reads `gaplicator_projects` from localStorage; auto-migrates the legacy `gaplicator_config` key as a "full" project on first run
- `saveProjects(projects)` — persists the projects array
- `createProject(name, type)` — creates a new project with a default config derived from the project name
- `relativeTime(iso)` — formats timestamps as "5m ago", "yesterday", etc.

### `web/src/components/ProjectsView.jsx` (new)
- Full projects list page with a responsive card grid
- "New Project" modal with name input and a type picker (Simple ⚡ / Full ⚙)
- Per-card Open and Delete actions; delete requires confirmation

### `web/src/yamlGenerator.js`
- `toSimpleType(field)` — maps full-schema field types to simple-schema types (`varchar→string`, FK→`rel`, enum values→`enum("a","b")`, etc.)
- `toSimpleFieldName(field)` — strips `_id` suffix from FK fields for cleaner output
- `generateSimpleYaml(config)` — builds the compact `models:` + `m2m:` YAML; deduplicates M2M pairs by sorting the model name pair
- `generateSimpleYamlHighlighted(config)` — syntax-highlighted version

### `web/src/App.jsx`
- Replaced single-config state with a `projects` array driven by `projectStorage`
- Renders `ProjectsView` when no project is active; renders the schema editor when a project is open
- Config changes are auto-saved to the active project with an updated `updatedAt` timestamp
- Editor header shows project name, type badge, and a `←` back button

### `web/src/components/YamlPreview.jsx`
- Accepts `fullYaml`, `fullHighlighted`, `simpleYaml`, `simpleHighlighted`, and `defaultTab` props
- Renders a Simple / Full pill-tab switcher; default tab follows the project's schema type but can be freely toggled

### `web/src/index.css`
- Styles for `.projects-page`, `.projects-grid`, `.project-card`, `.project-type-badge`
- Modal styles: `.new-project-modal-overlay`, `.new-project-modal`
- Schema type picker: `.schema-type-picker`, `.schema-type-btn`
- YAML preview tabs: `.preview-tabs`, `.preview-tab`
- Back button: `.btn-back`

## Implementation notes

- Migration is one-way and happens silently: if `gaplicator_projects` is absent but `gaplicator_config` exists, the old config is wrapped into a "full" project and saved under the new key
- Simple schema output strips `_id` FK suffixes and reconstructs `enum("…")` strings to match the format expected by `tools/simpleschema/main.go`
- M2M deduplication sorts the model name pair before keying into a `Set`, preventing duplicate junction table entries when both sides declare the relationship

---

This PR was written using [Vibe Kanban](https://vibekanban.com)