### PR TITLE
feat: generate README.md in output directory (Vibe Kanban)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -110,6 +110,13 @@ var buildCmd = &cobra.Command{
 				}
 				return writeExecutable(filepath.Join(out, "shutdown.sh"), content)
 			}},
+			{"Generating README.md", func() error {
+				content, err := generator.GenerateReadme(cfg)
+				if err != nil {
+					return err
+				}
+				return writeFile(filepath.Join(out, "README.md"), content)
+			}},
 			{"Generating client", func() error {
 				clientDir := filepath.Join(out, "client")
 				srcDir := filepath.Join(clientDir, "src")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -44,6 +44,9 @@ var ginRoutesTmpl string
 //go:embed templates/auth.go.tmpl
 var authGoTmpl string
 
+//go:embed templates/readme.md.tmpl
+var readmeTmpl string
+
 type AuthConfig struct {
 	Model string `yaml:"model"`
 }
@@ -855,6 +858,38 @@ func GenerateShutdownScript() (string, error) {
 	var buf strings.Builder
 	if err := template.Must(template.New("shutdown.sh").Parse(shutdownShTmpl)).Execute(&buf, nil); err != nil {
 		return "", fmt.Errorf("execute shutdown.sh template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func GenerateReadme(cfg *Config) (string, error) {
+	identityField := "email"
+	if cfg.Auth != nil {
+		for _, m := range cfg.Models {
+			if m.Name == cfg.Auth.Model {
+				identityField = detectIdentityField(m)
+				break
+			}
+		}
+	}
+	data := struct {
+		AppName       string
+		Port          int
+		IsMySQL       bool
+		HasAuth       bool
+		IdentityField string
+		Models        []Model
+	}{
+		AppName:       cfg.App.Name,
+		Port:          cfg.App.Port,
+		IsMySQL:       cfg.Database.Driver == "mysql",
+		HasAuth:       cfg.Auth != nil,
+		IdentityField: identityField,
+		Models:        cfg.Models,
+	}
+	var buf strings.Builder
+	if err := template.Must(template.New("readme.md").Parse(readmeTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute readme.md template: %w", err)
 	}
 	return buf.String(), nil
 }

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -1,0 +1,78 @@
+# {{.AppName}}
+
+Generated full-stack web application.
+
+## Stack
+
+| Layer    | Technology                      |
+|----------|---------------------------------|
+| Database | {{if .IsMySQL}}MySQL{{else}}PostgreSQL{{end}}              |
+| Server   | Go + Gin + GORM                 |
+| Client   | React + TypeScript + Vite       |
+
+## Getting started
+
+```bash
+# Start the database, apply migrations, and run the server
+./dev.sh
+
+# Stop all containers
+./shutdown.sh
+```
+
+The server listens on port **{{.Port}}**.
+The React dev server proxies API calls to the backend automatically.
+
+```bash
+# Start the frontend dev server (in a separate terminal)
+cd client && npm install && npm run dev
+```
+
+## Environment variables
+
+Configured in `.env`:
+
+| Variable      | Description                        |
+|---------------|------------------------------------|
+| `DB_HOST`     | Database host                      |
+| `DB_PORT`     | Database port                      |
+| `DB_USER`     | Database user                      |
+| `DB_PASSWORD` | Database password                  |
+| `DB_NAME`     | Database name                      |
+{{if .IsMySQL}}{{else}}| `DB_SSLMODE`  | SSL mode (default: `disable`)      |
+{{end}}{{if .HasAuth}}| `JWT_SECRET`  | Secret key for signing JWT tokens  |
+{{end}}
+## API
+{{if .HasAuth}}
+### Authentication
+
+| Method | Path              | Description                                      |
+|--------|-------------------|--------------------------------------------------|
+| `POST` | `/auth/register`  | Register — body: `{"{{.IdentityField}}": "...", "password": "..."}` |
+| `POST` | `/auth/login`     | Login — returns `{"token": "<jwt>"}` |
+
+All model routes require `Authorization: Bearer <token>`.
+{{end}}
+### Models
+{{range .Models}}
+#### `{{.Name}}`
+
+| Method   | Path                    | Description                                 |
+|----------|-------------------------|---------------------------------------------|
+| `GET`    | `/{{.Name}}`            | List (pagination, search, filter, sort)     |
+| `GET`    | `/{{.Name}}/:id`        | Get by id                                   |
+| `POST`   | `/{{.Name}}`            | Create                                      |
+| `PUT`    | `/{{.Name}}/:id`        | Update                                      |
+| `DELETE` | `/{{.Name}}/:id`        | Delete                                      |
+| `DELETE` | `/{{.Name}}/batch`      | Batch delete — body: `{"ids": [1, 2, 3]}`   |
+{{end}}
+### Query parameters (list endpoints)
+
+| Parameter     | Description                                                        |
+|---------------|--------------------------------------------------------------------|
+| `q`           | Full-text search across all text fields (case-insensitive)         |
+| `<field>`     | Filter by exact value (numeric, boolean, enum, or foreign key)     |
+| `sort_by`     | Field to sort by. Default: `id`                                    |
+| `sort_dir`    | `asc` or `desc`. Default: `desc`                                   |
+| `page`        | Page number (1-based). Default: `1`                                |
+| `limit`       | Results per page. Default: `20`, max: `100`                        |


### PR DESCRIPTION
## What was changed

Added a `README.md` generation step to the `gapp build` command. When building a project from a YAML config, a `README.md` is now automatically generated in the output directory alongside all other generated files.

## Why

The generated project had no documentation — developers had to figure out the stack, how to run the app, and what API endpoints were available by reading the code. The README provides this information at a glance.

## Implementation details

- **`internal/generator/templates/readme.md.tmpl`** — new Go template that renders the README using config data. Covers:
  - Stack table (database driver, Go+Gin+GORM, React+TS+Vite)
  - Getting started instructions (`./dev.sh`, `./shutdown.sh`, frontend dev server)
  - Environment variables table (conditionally includes `DB_SSLMODE` for Postgres and `JWT_SECRET` when auth is enabled)
  - Authentication endpoints (`/auth/register`, `/auth/login`) — rendered only when `auth:` is present in the config
  - Per-model route tables for all 6 CRUD endpoints
  - Query parameters reference (search, filter, sort, pagination)
- **`internal/generator/generator.go`** — added `//go:embed` directive for the new template and `GenerateReadme(cfg *Config) (string, error)` function. Detects the auth model's identity field using the existing `detectIdentityField` helper.
- **`cmd/build.go`** — added "Generating README.md" as step 11/12 in the build pipeline, between `shutdown.sh` and the client generation.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)