### PR TITLE
feat: remove hardcoded credentials from generated docker-compose.yml (Vibe Kanban)

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -764,19 +764,11 @@ func GenerateMain(cfg *Config, appImport string) (string, error) {
 
 func GenerateDockerCompose(cfg *Config) (string, error) {
 	data := struct {
-		Port       int
-		DBPort     int
-		DBName     string
-		DBUser     string
-		DBPassword string
-		IsMySQL    bool
+		DBUser  string
+		IsMySQL bool
 	}{
-		Port:       cfg.App.Port,
-		DBPort:     cfg.Database.Port,
-		DBName:     cfg.Database.Name,
-		DBUser:     cfg.Database.User,
-		DBPassword: cfg.Database.Password,
-		IsMySQL:    cfg.Database.Driver == "mysql",
+		DBUser:  cfg.Database.User,
+		IsMySQL: cfg.Database.Driver == "mysql",
 	}
 	var buf strings.Builder
 	if err := template.Must(template.New("docker-compose").Parse(dockerComposeTmpl)).Execute(&buf, data); err != nil {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -300,9 +300,9 @@ func TestGenerateDockerCompose_Services(t *testing.T) {
 		"app:",
 		"postgres:",
 		"image: postgres:16-alpine",
-		`"8080:8080"`,
+		`"${APP_PORT}:${APP_PORT}"`,
 		"DB_HOST: postgres",
-		"POSTGRES_DB: mydb",
+		"POSTGRES_DB: ${DB_NAME}",
 		"postgres_data:",
 		"service_healthy",
 	} {
@@ -323,11 +323,11 @@ func TestGenerateDockerCompose_PortAndDBName(t *testing.T) {
 		t.Fatalf("GenerateDockerCompose: %v", err)
 	}
 
-	if !strings.Contains(out, `"3000:3000"`) {
-		t.Error("expected port 3000 in app service")
+	if !strings.Contains(out, `"${APP_PORT}:${APP_PORT}"`) {
+		t.Error("expected APP_PORT env var reference in app service ports")
 	}
-	if !strings.Contains(out, "POSTGRES_DB: attendance_db") {
-		t.Error("expected POSTGRES_DB: attendance_db")
+	if !strings.Contains(out, "POSTGRES_DB: ${DB_NAME}") {
+		t.Error("expected POSTGRES_DB to reference env var")
 	}
 	if !strings.Contains(out, "pg_isready") {
 		t.Error("expected pg_isready healthcheck")

--- a/internal/generator/templates/docker-compose.yml.tmpl
+++ b/internal/generator/templates/docker-compose.yml.tmpl
@@ -2,16 +2,17 @@ services:
   app:
     build: .
     ports:
-      - "{{.Port}}:{{.Port}}"
+      - "${APP_PORT}:${APP_PORT}"
     environment:
 {{if .IsMySQL}}      DB_HOST: mysql
       DB_PORT: 3306
 {{else}}      DB_HOST: postgres
       DB_PORT: 5432
       DB_SSLMODE: disable
-{{end}}      DB_NAME: {{.DBName}}
-      DB_USER: {{.DBUser}}
-      DB_PASSWORD: {{.DBPassword}}
+{{end}}      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      APP_PORT: ${APP_PORT}
     depends_on:
 {{if .IsMySQL}}      mysql:
 {{else}}      postgres:
@@ -21,12 +22,12 @@ services:
 {{if .IsMySQL}}  mysql:
     image: mysql:8
     environment:
-      MYSQL_ROOT_PASSWORD: {{.DBPassword}}
-      MYSQL_DATABASE: {{.DBName}}
-{{if ne .DBUser "root"}}      MYSQL_USER: {{.DBUser}}
-      MYSQL_PASSWORD: {{.DBPassword}}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+{{if ne .DBUser "root"}}      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
 {{end}}    ports:
-      - "{{.DBPort}}:3306"
+      - "${DB_PORT}:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
@@ -38,15 +39,15 @@ services:
 {{else}}  postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: {{.DBUser}}
-      POSTGRES_PASSWORD: {{.DBPassword}}
-      POSTGRES_DB: {{.DBName}}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     ports:
-      - "{{.DBPort}}:5432"
+      - "${DB_PORT}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U {{.DBUser}} -d {{.DBName}}"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## What changed

The generated `docker-compose.yml` previously embedded database credentials and port values directly from the YAML config (e.g. `POSTGRES_PASSWORD: vova`). These values are now referenced as `${VAR}` placeholders, which Docker Compose resolves automatically from the `.env` file at runtime.

## Changes

### `docker-compose.yml.tmpl`
All hardcoded values replaced with environment variable references:

| Before | After |
|---|---|
| `"{{.Port}}:{{.Port}}"` | `"${APP_PORT}:${APP_PORT}"` |
| `DB_NAME: {{.DBName}}` | `DB_NAME: ${DB_NAME}` |
| `DB_USER: {{.DBUser}}` | `DB_USER: ${DB_USER}` |
| `DB_PASSWORD: {{.DBPassword}}` | `DB_PASSWORD: ${DB_PASSWORD}` |
| `POSTGRES_USER: {{.DBUser}}` | `POSTGRES_USER: ${DB_USER}` |
| `MYSQL_ROOT_PASSWORD: {{.DBPassword}}` | `MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}` |
| `"{{.DBPort}}:5432"` | `"${DB_PORT}:5432"` |
| `pg_isready -U {{.DBUser}} -d {{.DBName}}` | `pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB` |

The healthcheck command uses `$$` (Docker Compose escape) so the shell inside the container resolves `$POSTGRES_USER` and `$POSTGRES_DB` from the container's own environment — no credentials in the compose file at all.

### `GenerateDockerCompose` in `generator.go`
Stripped `Port`, `DBPort`, `DBName`, `DBPassword` from the template data struct — they are no longer needed since the template uses `${VAR}` literals. Only `DBUser` (for the MySQL root-user conditional) and `IsMySQL` remain.

## Why

With credentials baked into `docker-compose.yml`, any project committed to version control would leak passwords in plain text. Now the only file that ever contains actual credential values is `.env`, which should be git-ignored. Docker Compose reads `.env` from the project directory automatically, so no other changes are needed at runtime.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)