### PR TITLE
feat: prefix all API routes with /api/ (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ auth:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/auth/register` | Register — body: `{"email": "...", "password": "..."}` |
-| `POST` | `/auth/login` | Login — returns `{"token": "<jwt>"}` |
+| `POST` | `/api/auth/register` | Register — body: `{"email": "...", "password": "..."}` |
+| `POST` | `/api/auth/login` | Login — returns `{"token": "<jwt>"}` |
 
 The JWT token is valid for 24 hours and must be sent as `Authorization: Bearer <token>` on all model routes. The secret is read from the `JWT_SECRET` environment variable (set in the generated `.env`).
 
@@ -162,12 +162,12 @@ Every model gets the following routes:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/{model}` | List with pagination, filtering, search, and sorting |
-| `GET` | `/{model}/:id` | Get single item |
-| `POST` | `/{model}` | Create item |
-| `PUT` | `/{model}/:id` | Update item |
-| `DELETE` | `/{model}/:id` | Delete single item |
-| `DELETE` | `/{model}/batch` | Batch delete — request body: `{"ids": [1, 2, 3]}` |
+| `GET` | `/api/{model}` | List with pagination, filtering, search, and sorting |
+| `GET` | `/api/{model}/:id` | Get single item |
+| `POST` | `/api/{model}` | Create item |
+| `PUT` | `/api/{model}/:id` | Update item |
+| `DELETE` | `/api/{model}/:id` | Delete single item |
+| `DELETE` | `/api/{model}/batch` | Batch delete — request body: `{"ids": [1, 2, 3]}` |
 
 ### Filtering, search & sorting
 
@@ -182,7 +182,7 @@ Every list endpoint supports filtering, full-text search, sorting, and paginatio
 | `page` | Page number (1-based). Default: `1` |
 | `limit` | Results per page. Default: `20`, max: `100` |
 
-**Example:** `GET /posts?q=hello&status=draft&author_id=5&sort_by=title&sort_dir=desc&page=2&limit=20`
+**Example:** `GET /api/posts?q=hello&status=draft&author_id=5&sort_by=title&sort_dir=desc&page=2&limit=20`
 
 The React frontend generates corresponding UI controls: a search input, filter dropdowns for enum/boolean/FK fields, sortable column headers, pagination, and checkbox-based batch delete.
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -610,8 +610,8 @@ func TestGenerateReactAPI_FetchMethods(t *testing.T) {
 
 func TestGenerateReactAPI_BaseURL(t *testing.T) {
 	out := GenerateReactAPI(clientTestModel, false)
-	if !strings.Contains(out, "const BASE = '/students';") {
-		t.Error("expected BASE = '/students'")
+	if !strings.Contains(out, "const BASE = '/api/students';") {
+		t.Error("expected BASE = '/api/students'")
 	}
 }
 
@@ -724,8 +724,8 @@ func TestGenerateReactViteConfig_Proxy(t *testing.T) {
 
 	for _, want := range []string{
 		"proxy:",
-		"'/students': 'http://localhost:3000'",
-		"'/subjects': 'http://localhost:3000'",
+		"'/api/students': 'http://localhost:3000'",
+		"'/api/subjects': 'http://localhost:3000'",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in vite.config.ts", want)
@@ -2127,11 +2127,11 @@ func TestGenerateAuthGo_RegisterRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateAuthGo returned error: %v", err)
 	}
-	if !strings.Contains(out, `"/auth/register"`) {
-		t.Error("expected /auth/register route")
+	if !strings.Contains(out, `"/api/auth/register"`) {
+		t.Error("expected /api/auth/register route")
 	}
-	if !strings.Contains(out, `"/auth/login"`) {
-		t.Error("expected /auth/login route")
+	if !strings.Contains(out, `"/api/auth/login"`) {
+		t.Error("expected /api/auth/login route")
 	}
 }
 

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -29,8 +29,8 @@ func getJWTSecret() []byte {
 }
 
 func RegisterAuthRoutes(r *gin.Engine, db *gorm.DB) {
-	r.POST("/auth/register", registerHandler(db))
-	r.POST("/auth/login", loginHandler(db))
+	r.POST("/api/auth/register", registerHandler(db))
+	r.POST("/api/auth/login", loginHandler(db))
 }
 
 func registerHandler(db *gorm.DB) gin.HandlerFunc {

--- a/internal/generator/templates/main.go.tmpl
+++ b/internal/generator/templates/main.go.tmpl
@@ -54,10 +54,11 @@ func main() {
 
 {{if .HasAuth}}	RegisterAuthRoutes(r, db)
 
-	authenticated := r.Group("/")
+	authenticated := r.Group("/api")
 	authenticated.Use(JWTMiddleware())
 	routes.RegisterRoutes(authenticated, db)
-{{else}}	routes.RegisterRoutes(r, db)
+{{else}}	api := r.Group("/api")
+	routes.RegisterRoutes(api, db)
 {{end}}	if err := r.Run(":" + os.Getenv("APP_PORT")); err != nil {
 		log.Fatalf("server: %v", err)
 	}

--- a/internal/generator/templates/react_api_ts.tmpl
+++ b/internal/generator/templates/react_api_ts.tmpl
@@ -6,7 +6,7 @@ function authHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 {{end}}
-const BASE = '/{{.PluralRaw}}';
+const BASE = '/api/{{.PluralRaw}}';
 
 export interface Paginated{{.PluralName}} { data: {{.StructName}}[]; total: number; page: number; limit: number; }
 

--- a/internal/generator/templates/react_auth_api_ts.tmpl
+++ b/internal/generator/templates/react_auth_api_ts.tmpl
@@ -3,7 +3,7 @@ export interface RegisterInput { {{.IdentityField}}: string; password: string; }
 export interface AuthResponse { token: string; }
 
 export async function login(data: LoginInput): Promise<AuthResponse> {
-  const res = await fetch('/auth/login', {
+  const res = await fetch('/api/auth/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -13,7 +13,7 @@ export async function login(data: LoginInput): Promise<AuthResponse> {
 }
 
 export async function register(data: RegisterInput): Promise<{ id: number }> {
-  const res = await fetch('/auth/register', {
+  const res = await fetch('/api/auth/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),

--- a/internal/generator/templates/react_vite_config.tmpl
+++ b/internal/generator/templates/react_vite_config.tmpl
@@ -5,8 +5,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-{{range .Models}}      '/{{.Name}}': 'http://localhost:{{$.Port}}',
-{{end}}{{if .HasAuth}}      '/auth': 'http://localhost:{{.Port}}',
+{{range .Models}}      '/api/{{.Name}}': 'http://localhost:{{$.Port}}',
+{{end}}{{if .HasAuth}}      '/api/auth': 'http://localhost:{{.Port}}',
 {{end}}    },
   },
 })

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -48,8 +48,8 @@ Configured in `.env`:
 
 | Method | Path              | Description                                      |
 |--------|-------------------|--------------------------------------------------|
-| `POST` | `/auth/register`  | Register — body: `{"{{.IdentityField}}": "...", "password": "..."}` |
-| `POST` | `/auth/login`     | Login — returns `{"token": "<jwt>"}` |
+| `POST` | `/api/auth/register`  | Register — body: `{"{{.IdentityField}}": "...", "password": "..."}` |
+| `POST` | `/api/auth/login`     | Login — returns `{"token": "<jwt>"}` |
 
 All model routes require `Authorization: Bearer <token>`.
 {{end}}
@@ -59,12 +59,12 @@ All model routes require `Authorization: Bearer <token>`.
 
 | Method   | Path                    | Description                                 |
 |----------|-------------------------|---------------------------------------------|
-| `GET`    | `/{{.Name}}`            | List (pagination, search, filter, sort)     |
-| `GET`    | `/{{.Name}}/:id`        | Get by id                                   |
-| `POST`   | `/{{.Name}}`            | Create                                      |
-| `PUT`    | `/{{.Name}}/:id`        | Update                                      |
-| `DELETE` | `/{{.Name}}/:id`        | Delete                                      |
-| `DELETE` | `/{{.Name}}/batch`      | Batch delete — body: `{"ids": [1, 2, 3]}`   |
+| `GET`    | `/api/{{.Name}}`            | List (pagination, search, filter, sort)     |
+| `GET`    | `/api/{{.Name}}/:id`        | Get by id                                   |
+| `POST`   | `/api/{{.Name}}`            | Create                                      |
+| `PUT`    | `/api/{{.Name}}/:id`        | Update                                      |
+| `DELETE` | `/api/{{.Name}}/:id`        | Delete                                      |
+| `DELETE` | `/api/{{.Name}}/batch`      | Batch delete — body: `{"ids": [1, 2, 3]}`   |
 {{end}}
 ### Query parameters (list endpoints)
 


### PR DESCRIPTION
## What changed

All generated API routes (both backend and frontend) are now served under the `/api/` prefix.

### Backend (Go/Gin templates)

- **`auth.go.tmpl`**: Auth endpoints changed from `/auth/login` and `/auth/register` to `/api/auth/login` and `/api/auth/register`.
- **`main.go.tmpl`**: CRUD routes are now grouped under `/api` instead of being registered on the root router — both the authenticated (`r.Group("/api")` + JWT middleware) and unauthenticated (`api := r.Group("/api")`) code paths.

### Frontend (React/TypeScript templates)

- **`react_api_ts.tmpl`**: The `BASE` constant for CRUD API calls updated from `'/<model>'` to `'/api/<model>'`.
- **`react_auth_api_ts.tmpl`**: Auth fetch calls updated from `/auth/login` / `/auth/register` to `/api/auth/login` / `/api/auth/register`.

## Why

Prefixing all routes with `/api/` is a standard convention that makes it easy to distinguish API traffic from static/frontend assets. It also simplifies reverse-proxy and CDN configuration (e.g. route `/api/*` to the backend, everything else to the frontend).

## Implementation notes

- The route prefix is applied at the router group level in `main.go.tmpl` for CRUD routes, so individual handler templates (`gin_routes.go.tmpl`) required no changes.
- Auth routes are registered directly on the root engine (outside the group) so they needed explicit path updates in `auth.go.tmpl`.
- Frontend templates mirror the backend paths exactly, keeping both sides in sync.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)