### PR TITLE
feat: add Node.js (Express + Prisma) alternative backend (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generate a full-stack web application (database + server + client) from a single
 
 - **Go 1.21+** — to install and run gaplicator
 - **Docker** — to run the database via the generated `dev.sh`
-- **Node.js 18+** — to run the generated React frontend
+- **Node.js 18+** — to run the generated React frontend (and the Node.js backend when `server: node`)
 
 ## Quick start
 
@@ -47,11 +47,12 @@ To stop: `./shutdown.sh`
 
 ## Stack
 
-| Layer    | Technology                    |
-|----------|-------------------------------|
-| Database | PostgreSQL or MySQL           |
-| Server   | Go + Gin + GORM               |
-| Client   | React + TypeScript + Vite     |
+| Layer    | Technology                               |
+|----------|------------------------------------------|
+| Database | PostgreSQL or MySQL                      |
+| Server   | Go + Gin + GORM *(default)*              |
+|          | Node.js + Express + Prisma *(optional)*  |
+| Client   | React + TypeScript + Vite                |
 
 ## Usage
 
@@ -67,8 +68,9 @@ gaplicator build <config.yaml> [-o <output-dir>]
 
 ```yaml
 app:
-  name: my-app   # lowercase letters, digits, hyphens, underscores; used as Go module name
+  name: my-app   # lowercase letters, digits, hyphens, underscores; used as module name
   port: 8080     # 1–65535
+  server: go     # optional: "go" (default) or "node"
 
 database:
   driver: postgres # optional: "postgres" (default) or "mysql"
@@ -136,49 +138,72 @@ All models include an auto-generated `id` primary key. The field names `id`, `cr
 
 ## What gets generated
 
-Running `gaplicator build app.yaml` produces:
+Running `gaplicator build app.yaml` produces different backend files depending on `app.server`.
+
+### `server: go` (default)
 
 ```
 dist/
 ├── main.go                        # Gin server + GORM auto-migrate
 ├── auth.go                        # JWT handlers — only with auth: config
 ├── go.mod                         # module with gin/gorm/postgres deps
-├── docker-compose.yml             # app + postgres services
+├── docker-compose.yml             # app + postgres/mysql services
 ├── .env                           # DB credentials (+ JWT_SECRET with auth:)
 ├── dev.sh                         # one-command dev startup (see below)
 ├── shutdown.sh                    # stops docker containers
 ├── migrations/
-│   ├── 001_initial.up.sql
-│   └── 001_initial.down.sql
+│   └── 001_initial.up.sql
 ├── models/
-│   └── models.go                  # GORM structs (password field hidden with json:"-")
+│   └── models.go                  # GORM structs (password hidden with json:"-")
 ├── routes/
 │   └── routes.go                  # Gin CRUD handlers
-└── client/                        # React + TypeScript frontend
-    ├── package.json               # react, react-router-dom, vite
-    ├── index.html
-    ├── vite.config.ts             # dev proxy → Go backend
-    ├── tsconfig.json
-    └── src/
-        ├── main.tsx
-        ├── App.tsx                # nav + routes (ProtectedRoute wrapping with auth:)
-        ├── context/
-        │   └── AuthContext.tsx   # AuthProvider, useAuth, getToken — only with auth:
-        ├── types/
-        │   └── {model}.ts        # TypeScript interfaces
-        ├── api/
-        │   ├── auth.ts           # login/register fetch functions — only with auth:
-        │   └── {model}.ts        # fetch wrappers (Authorization header with auth:)
-        └── pages/
-            ├── LoginPage.tsx     # only with auth:
-            ├── RegisterPage.tsx  # only with auth:
-            └── {Model}Page.tsx   # CRUD table + inline form
+└── client/                        # React + TypeScript frontend (same for both backends)
 ```
 
-`dev.sh` does three things in order:
-1. Starts the database container (`postgres` or `mysql` depending on `database.driver`)
-2. Waits for the database to be healthy, then applies `migrations/001_initial.up.sql`
-3. Starts the Go server with `go run .`
+`dev.sh` order: start DB container → wait healthy → apply `migrations/001_initial.up.sql` → `go run .`
+
+### `server: node`
+
+```
+dist/
+├── index.js                       # Express server entry point
+├── routes.js                      # CRUD handlers for all models
+├── auth.js                        # bcrypt + JWT — only with auth: config
+├── package.json                   # express, @prisma/client, bcryptjs, jsonwebtoken
+├── prisma/
+│   └── schema.prisma              # Prisma schema (models, relations, @@map)
+├── docker-compose.yml             # app + postgres/mysql services
+├── .env                           # DB credentials (DATABASE_URL + JWT_SECRET)
+├── dev.sh                         # one-command dev startup (see below)
+├── shutdown.sh                    # stops docker containers
+└── client/                        # React + TypeScript frontend (same for both backends)
+```
+
+`dev.sh` order: start DB container → wait healthy → `npx prisma migrate deploy` → `npm run dev`
+
+Both backends produce an identical React client under `client/`:
+
+```
+client/
+├── package.json               # react, react-router-dom, vite
+├── index.html
+├── vite.config.ts             # dev proxy → backend
+├── tsconfig.json
+└── src/
+    ├── main.tsx
+    ├── App.tsx                # nav + routes (ProtectedRoute wrapping with auth:)
+    ├── context/
+    │   └── AuthContext.tsx   # AuthProvider, useAuth, getToken — only with auth:
+    ├── types/
+    │   └── {model}.ts        # TypeScript interfaces
+    ├── api/
+    │   ├── auth.ts           # login/register fetch functions — only with auth:
+    │   └── {model}.ts        # fetch wrappers (Authorization header with auth:)
+    └── pages/
+        ├── LoginPage.tsx     # only with auth:
+        ├── RegisterPage.tsx  # only with auth:
+        └── {Model}Page.tsx   # CRUD table + inline form
+```
 
 No local database client required — migrations run inside the container.
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,149 +33,237 @@ var buildCmd = &cobra.Command{
 		}
 
 		out := outputPath
-		steps := []struct {
+
+		var backendSteps []struct {
 			name string
 			fn   func() error
-		}{
-			{"Generating migrations", func() error {
-				dir := filepath.Join(out, "migrations")
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(dir, "001_initial.up.sql"), generator.GenerateMigrationUp(cfg.Models, cfg.Database.Driver))
-			}},
-			{"Generating models", func() error {
-				dir := filepath.Join(out, "models")
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(dir, "models.go"), generator.GenerateGORMModels(cfg.Models, "models", cfg.Auth))
-			}},
-			{"Generating routes", func() error {
-				dir := filepath.Join(out, "routes")
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(dir, "routes.go"), generator.GenerateGinRoutes(cfg.Models, "routes", cfg.App.Name+"/models", cfg.Database.Driver == "mysql"))
-			}},
-			{"Generating main.go", func() error {
-				content, err := generator.GenerateMain(cfg, cfg.App.Name)
-				if err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(out, "main.go"), content)
-			}},
-			{"Generating auth.go", func() error {
-				if cfg.Auth == nil {
-					return nil
-				}
-				content, err := generator.GenerateAuthGo(cfg, cfg.App.Name)
-				if err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(out, "auth.go"), content)
-			}},
-			{"Generating docker-compose.yml", func() error {
-				content, err := generator.GenerateDockerCompose(cfg)
-				if err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(out, "docker-compose.yml"), content)
-			}},
-			{"Generating go.mod", func() error {
-				content, err := generator.GenerateGoMod(cfg)
-				if err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(out, "go.mod"), content)
-			}},
-			{"Generating .env", func() error {
-				content, err := generator.GenerateEnv(cfg)
-				if err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(out, ".env"), content)
-			}},
-			{"Generating dev.sh", func() error {
-				content, err := generator.GenerateDevScript(cfg)
-				if err != nil {
-					return err
-				}
-				return writeExecutable(filepath.Join(out, "dev.sh"), content)
-			}},
-			{"Generating shutdown.sh", func() error {
-				content, err := generator.GenerateShutdownScript()
-				if err != nil {
-					return err
-				}
-				return writeExecutable(filepath.Join(out, "shutdown.sh"), content)
-			}},
-			{"Generating README.md", func() error {
-				content, err := generator.GenerateReadme(cfg)
-				if err != nil {
-					return err
-				}
-				return writeFile(filepath.Join(out, "README.md"), content)
-			}},
-			{"Generating client", func() error {
-				clientDir := filepath.Join(out, "client")
-				srcDir := filepath.Join(clientDir, "src")
-				dirs := []string{
-					filepath.Join(srcDir, "types"),
-					filepath.Join(srcDir, "api"),
-					filepath.Join(srcDir, "pages"),
-				}
-				if cfg.Auth != nil {
-					dirs = append(dirs, filepath.Join(srcDir, "context"))
-				}
-				for _, dir := range dirs {
+		}
+
+		if cfg.App.Server == "node" {
+			backendSteps = []struct {
+				name string
+				fn   func() error
+			}{
+				{"Generating package.json", func() error {
+					content, err := generator.GenerateNodePackageJSON(cfg)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "package.json"), content)
+				}},
+				{"Generating index.js", func() error {
+					content, err := generator.GenerateNodeIndex(cfg)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "index.js"), content)
+				}},
+				{"Generating routes.js", func() error {
+					content, err := generator.GenerateNodeRoutes(cfg)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "routes.js"), content)
+				}},
+				{"Generating auth.js", func() error {
+					if cfg.Auth == nil {
+						return nil
+					}
+					content, err := generator.GenerateNodeAuth(cfg)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "auth.js"), content)
+				}},
+				{"Generating prisma/schema.prisma", func() error {
+					dir := filepath.Join(out, "prisma")
 					if err := os.MkdirAll(dir, 0755); err != nil {
 						return err
 					}
+					content, err := generator.GenerateNodePrismaSchema(cfg)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(dir, "schema.prisma"), content)
+				}},
+			}
+		} else {
+			backendSteps = []struct {
+				name string
+				fn   func() error
+			}{
+				{"Generating migrations", func() error {
+					dir := filepath.Join(out, "migrations")
+					if err := os.MkdirAll(dir, 0755); err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(dir, "001_initial.up.sql"), generator.GenerateMigrationUp(cfg.Models, cfg.Database.Driver))
+				}},
+				{"Generating models", func() error {
+					dir := filepath.Join(out, "models")
+					if err := os.MkdirAll(dir, 0755); err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(dir, "models.go"), generator.GenerateGORMModels(cfg.Models, "models", cfg.Auth))
+				}},
+				{"Generating routes", func() error {
+					dir := filepath.Join(out, "routes")
+					if err := os.MkdirAll(dir, 0755); err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(dir, "routes.go"), generator.GenerateGinRoutes(cfg.Models, "routes", cfg.App.Name+"/models", cfg.Database.Driver == "mysql"))
+				}},
+				{"Generating main.go", func() error {
+					content, err := generator.GenerateMain(cfg, cfg.App.Name)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "main.go"), content)
+				}},
+				{"Generating auth.go", func() error {
+					if cfg.Auth == nil {
+						return nil
+					}
+					content, err := generator.GenerateAuthGo(cfg, cfg.App.Name)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "auth.go"), content)
+				}},
+				{"Generating go.mod", func() error {
+					content, err := generator.GenerateGoMod(cfg)
+					if err != nil {
+						return err
+					}
+					return writeFile(filepath.Join(out, "go.mod"), content)
+				}},
+			}
+		}
+
+		devShStep := struct {
+			name string
+			fn   func() error
+		}{"Generating dev.sh", func() error {
+			var content string
+			var err error
+			if cfg.App.Server == "node" {
+				content, err = generator.GenerateNodeDevScript(cfg)
+			} else {
+				content, err = generator.GenerateDevScript(cfg)
+			}
+			if err != nil {
+				return err
+			}
+			return writeExecutable(filepath.Join(out, "dev.sh"), content)
+		}}
+
+		steps := []struct {
+			name string
+			fn   func() error
+		}{}
+		steps = append(steps, backendSteps...)
+		steps = append(steps, struct {
+			name string
+			fn   func() error
+		}{"Generating docker-compose.yml", func() error {
+			content, err := generator.GenerateDockerCompose(cfg)
+			if err != nil {
+				return err
+			}
+			return writeFile(filepath.Join(out, "docker-compose.yml"), content)
+		}})
+		steps = append(steps, struct {
+			name string
+			fn   func() error
+		}{"Generating .env", func() error {
+			content, err := generator.GenerateEnv(cfg)
+			if err != nil {
+				return err
+			}
+			return writeFile(filepath.Join(out, ".env"), content)
+		}})
+		steps = append(steps, devShStep)
+		steps = append(steps, struct {
+			name string
+			fn   func() error
+		}{"Generating shutdown.sh", func() error {
+			content, err := generator.GenerateShutdownScript()
+			if err != nil {
+				return err
+			}
+			return writeExecutable(filepath.Join(out, "shutdown.sh"), content)
+		}})
+		steps = append(steps, struct {
+			name string
+			fn   func() error
+		}{"Generating README.md", func() error {
+			content, err := generator.GenerateReadme(cfg)
+			if err != nil {
+				return err
+			}
+			return writeFile(filepath.Join(out, "README.md"), content)
+		}})
+		steps = append(steps, struct {
+			name string
+			fn   func() error
+		}{"Generating client", func() error {
+			clientDir := filepath.Join(out, "client")
+			srcDir := filepath.Join(clientDir, "src")
+			dirs := []string{
+				filepath.Join(srcDir, "types"),
+				filepath.Join(srcDir, "api"),
+				filepath.Join(srcDir, "pages"),
+			}
+			if cfg.Auth != nil {
+				dirs = append(dirs, filepath.Join(srcDir, "context"))
+			}
+			for _, dir := range dirs {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return err
 				}
-				static := map[string]string{
-					filepath.Join(clientDir, "package.json"):    generator.GenerateReactPackageJSON(cfg),
-					filepath.Join(clientDir, "index.html"):      generator.GenerateReactIndexHTML(cfg),
-					filepath.Join(clientDir, "vite.config.ts"):  generator.GenerateReactViteConfig(cfg),
-					filepath.Join(clientDir, "tsconfig.json"):   generator.GenerateReactTsConfig(),
-					filepath.Join(srcDir, "main.tsx"):            generator.GenerateReactMain(),
-					filepath.Join(srcDir, "app.css"):             generator.GenerateReactAppCSS(),
-					filepath.Join(srcDir, "App.tsx"):             generator.GenerateReactApp(cfg.Models, cfg.Auth != nil),
+			}
+			static := map[string]string{
+				filepath.Join(clientDir, "package.json"):   generator.GenerateReactPackageJSON(cfg),
+				filepath.Join(clientDir, "index.html"):     generator.GenerateReactIndexHTML(cfg),
+				filepath.Join(clientDir, "vite.config.ts"): generator.GenerateReactViteConfig(cfg),
+				filepath.Join(clientDir, "tsconfig.json"):  generator.GenerateReactTsConfig(),
+				filepath.Join(srcDir, "main.tsx"):          generator.GenerateReactMain(),
+				filepath.Join(srcDir, "app.css"):           generator.GenerateReactAppCSS(),
+				filepath.Join(srcDir, "App.tsx"):           generator.GenerateReactApp(cfg.Models, cfg.Auth != nil),
+			}
+			for path, content := range static {
+				if err := writeFile(path, content); err != nil {
+					return err
 				}
-				for path, content := range static {
+			}
+			if cfg.Auth != nil {
+				authFiles := map[string]string{
+					filepath.Join(srcDir, "context", "AuthContext.tsx"): generator.GenerateReactAuthContext(),
+					filepath.Join(srcDir, "api", "auth.ts"):            generator.GenerateReactAuthAPI(cfg),
+					filepath.Join(srcDir, "pages", "LoginPage.tsx"):    generator.GenerateReactLoginPage(cfg),
+					filepath.Join(srcDir, "pages", "RegisterPage.tsx"): generator.GenerateReactRegisterPage(cfg),
+				}
+				for path, content := range authFiles {
 					if err := writeFile(path, content); err != nil {
 						return err
 					}
 				}
-				if cfg.Auth != nil {
-					authFiles := map[string]string{
-						filepath.Join(srcDir, "context", "AuthContext.tsx"): generator.GenerateReactAuthContext(),
-						filepath.Join(srcDir, "api", "auth.ts"):             generator.GenerateReactAuthAPI(cfg),
-						filepath.Join(srcDir, "pages", "LoginPage.tsx"):     generator.GenerateReactLoginPage(cfg),
-						filepath.Join(srcDir, "pages", "RegisterPage.tsx"):  generator.GenerateReactRegisterPage(cfg),
-					}
-					for path, content := range authFiles {
-						if err := writeFile(path, content); err != nil {
-							return err
-						}
-					}
+			}
+			for _, m := range cfg.Models {
+				base := generator.ModelFileBasename(m)
+				structName := generator.ModelStructName(m)
+				if err := writeFile(filepath.Join(srcDir, "types", base+".ts"), generator.GenerateReactTypes(m, cfg.Models)); err != nil {
+					return err
 				}
-				for _, m := range cfg.Models {
-					base := generator.ModelFileBasename(m)
-					structName := generator.ModelStructName(m)
-					if err := writeFile(filepath.Join(srcDir, "types", base+".ts"), generator.GenerateReactTypes(m, cfg.Models)); err != nil {
-						return err
-					}
-					if err := writeFile(filepath.Join(srcDir, "api", base+".ts"), generator.GenerateReactAPI(m, cfg.Auth != nil)); err != nil {
-						return err
-					}
-					if err := writeFile(filepath.Join(srcDir, "pages", structName+"Page.tsx"), generator.GenerateReactPage(m, cfg.Models)); err != nil {
-						return err
-					}
+				if err := writeFile(filepath.Join(srcDir, "api", base+".ts"), generator.GenerateReactAPI(m, cfg.Auth != nil)); err != nil {
+					return err
 				}
-				return nil
-			}},
-		}
+				if err := writeFile(filepath.Join(srcDir, "pages", structName+"Page.tsx"), generator.GenerateReactPage(m, cfg.Models)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}})
 
 		if err := os.MkdirAll(out, 0755); err != nil {
 			return fmt.Errorf("create output dir: %w", err)

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,7 @@ A gaplicator config file is a YAML document with up to four top-level sections: 
 app:
   name: my-app
   port: 8080
+  server: go        # optional: "go" (default) or "node"
 
 database:
   driver: postgres  # optional: "postgres" (default) or "mysql"
@@ -27,10 +28,20 @@ models:
 
 ## `app`
 
-| Key | Type | Required | Description |
-|-----|------|----------|-------------|
-| `name` | string | yes | Application name. Used as the Go module name and React app title. Must match `^[a-z][a-z0-9_-]*$` (lowercase letters, digits, hyphens, underscores). |
-| `port` | int | yes | HTTP port the generated server listens on. Must be between 1 and 65535. |
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `name` | string | yes | — | Application name. Used as the module name and React app title. Must match `^[a-z][a-z0-9_-]*$` (lowercase letters, digits, hyphens, underscores). |
+| `port` | int | yes | — | HTTP port the generated server listens on. Must be between 1 and 65535. |
+| `server` | string | no | `go` | Backend server to generate. Accepted values: `go` (Gin + GORM), `node` (Express + Prisma). |
+
+### Server backends
+
+| Value | Stack | Entry point | ORM / DB layer | Auth deps |
+|-------|-------|-------------|----------------|-----------|
+| `go` | Go + Gin + GORM | `main.go` | GORM migrations (`migrations/`) | `golang-jwt/jwt`, `golang.org/x/crypto` |
+| `node` | Node.js + Express + Prisma | `index.js` | Prisma schema (`prisma/schema.prisma`) | `bcryptjs`, `jsonwebtoken` |
+
+Both backends expose identical REST routes and share the same React client.
 
 ---
 
@@ -67,11 +78,12 @@ Optional. When present, enables JWT-based authentication for the generated app.
 
 **What gets generated when `auth` is set:**
 
-- **`auth.go`** — `POST /auth/register` and `POST /auth/login` handlers (bcrypt + JWT HS256), plus `JWTMiddleware` that validates the `Authorization: Bearer <token>` header
+- **`auth.go`** *(server: go)* / **`auth.js`** *(server: node)* — `POST /api/auth/register` and `POST /api/auth/login` handlers (bcrypt + JWT HS256), plus JWT middleware that validates the `Authorization: Bearer <token>` header
 - All model CRUD routes are mounted behind the JWT middleware — unauthenticated requests get `401`
-- **`go.mod`** — adds `golang-jwt/jwt/v5` and `golang.org/x/crypto`
+- **`go.mod`** *(server: go)* — adds `golang-jwt/jwt/v5` and `golang.org/x/crypto`
+- **`package.json`** *(server: node)* — adds `bcryptjs` and `jsonwebtoken`
 - **`.env`** — adds `JWT_SECRET=change-me-in-production`
-- **`models/models.go`** — the `password` field gets `json:"-"` so it is never included in API responses
+- **`models/models.go`** *(server: go)* — the `password` field gets `json:"-"` so it is never included in API responses
 - **React client** — `AuthContext`, `LoginPage`, `RegisterPage`, `ProtectedRoute`, and `Authorization` headers on all fetch calls
 
 **Identity field** — the field used as the login identifier is auto-detected from the auth model: `email` takes priority over `username`, then the first `varchar`/`text` field.

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -47,6 +47,24 @@ var authGoTmpl string
 //go:embed templates/readme.md.tmpl
 var readmeTmpl string
 
+//go:embed templates/node_package_json.tmpl
+var nodePackageJSONTmpl string
+
+//go:embed templates/node_index_js.tmpl
+var nodeIndexJSTmpl string
+
+//go:embed templates/node_routes_js.tmpl
+var nodeRoutesJSTmpl string
+
+//go:embed templates/node_auth_js.tmpl
+var nodeAuthJSTmpl string
+
+//go:embed templates/node_prisma_schema.tmpl
+var nodePrismaSchmaTmpl string
+
+//go:embed templates/node_dev_sh.tmpl
+var nodeDevShTmpl string
+
 type AuthConfig struct {
 	Model string `yaml:"model"`
 }
@@ -59,8 +77,9 @@ type Config struct {
 }
 
 type AppConfig struct {
-	Name string `yaml:"name"`
-	Port int    `yaml:"port"`
+	Name   string `yaml:"name"`
+	Port   int    `yaml:"port"`
+	Server string `yaml:"server"` // "go" (default) or "node"
 }
 
 type DatabaseConfig struct {
@@ -116,6 +135,9 @@ func ParseConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse yaml: %w", err)
 	}
 
+	if cfg.App.Server == "" {
+		cfg.App.Server = "go"
+	}
 	if cfg.Database.Driver == "" {
 		cfg.Database.Driver = "postgres"
 	}
@@ -191,6 +213,11 @@ func ValidateConfig(cfg *Config) []error {
 	}
 	if cfg.App.Port < 1 || cfg.App.Port > 65535 {
 		errs = append(errs, fmt.Errorf("app.port must be between 1 and 65535"))
+	}
+	if cfg.App.Server == "" {
+		cfg.App.Server = "go"
+	} else if cfg.App.Server != "go" && cfg.App.Server != "node" {
+		errs = append(errs, fmt.Errorf("app.server must be \"go\" or \"node\""))
 	}
 	if cfg.Database.Driver == "" {
 		cfg.Database.Driver = "postgres"

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -275,7 +275,7 @@ func TestGenerateMain_RouterAndServer(t *testing.T) {
 
 	for _, want := range []string{
 		"gin.Default()",
-		"routes.RegisterRoutes(r, db)",
+		"routes.RegisterRoutes(api, db)",
 		`os.Getenv("APP_PORT")`,
 	} {
 		if !strings.Contains(out, want) {
@@ -2202,7 +2202,7 @@ func TestGenerateMain_WithAuth(t *testing.T) {
 	if !strings.Contains(out, "JWTMiddleware()") {
 		t.Error("expected JWTMiddleware() call")
 	}
-	if !strings.Contains(out, `r.Group("/")`) {
+	if !strings.Contains(out, `r.Group("/api")`) {
 		t.Error("expected authenticated group")
 	}
 }
@@ -2220,8 +2220,8 @@ func TestGenerateMain_WithoutAuth(t *testing.T) {
 	if strings.Contains(out, "RegisterAuthRoutes") {
 		t.Error("expected no RegisterAuthRoutes when auth is disabled")
 	}
-	if !strings.Contains(out, "routes.RegisterRoutes(r, db)") {
-		t.Error("expected direct routes.RegisterRoutes(r, db) call")
+	if !strings.Contains(out, "routes.RegisterRoutes(api, db)") {
+		t.Error("expected direct routes.RegisterRoutes(api, db) call")
 	}
 }
 

--- a/internal/generator/node_generator.go
+++ b/internal/generator/node_generator.go
@@ -1,0 +1,375 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// ── package.json ──────────────────────────────────────────────────────────────
+
+func GenerateNodePackageJSON(cfg *Config) (string, error) {
+	data := struct {
+		AppName string
+		HasAuth bool
+	}{AppName: cfg.App.Name, HasAuth: cfg.Auth != nil}
+	var buf strings.Builder
+	if err := template.Must(template.New("node_package_json").Parse(nodePackageJSONTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute node_package_json template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ── index.js ──────────────────────────────────────────────────────────────────
+
+func GenerateNodeIndex(cfg *Config) (string, error) {
+	data := struct {
+		Port    int
+		HasAuth bool
+	}{Port: cfg.App.Port, HasAuth: cfg.Auth != nil}
+	var buf strings.Builder
+	if err := template.Must(template.New("node_index_js").Parse(nodeIndexJSTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute node_index_js template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ── routes.js ─────────────────────────────────────────────────────────────────
+
+type nodeFilterColumn struct {
+	Name      string
+	IsNumeric bool
+	IsBool    bool
+}
+
+type nodeM2MRelation struct {
+	Field     string // camelCase plural  e.g. "tags"
+	ModelName string // PascalCase        e.g. "Tag"
+	IdsField  string // e.g. "tag_ids"
+	JoinTable string
+}
+
+type nodeModelData struct {
+	Name          string
+	CamelName     string
+	SortColumns   []string
+	SearchColumns []string
+	FilterColumns []nodeFilterColumn
+	HasM2M        bool
+	M2MRelations  []nodeM2MRelation
+	HasPlainFields bool
+}
+
+type nodeRoutesData struct {
+	Models []nodeModelData
+	IsPg   bool
+}
+
+func toCamelCase(s string) string {
+	parts := strings.Split(s, "_")
+	if len(parts) == 0 {
+		return s
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		if p == "" {
+			continue
+		}
+		out += strings.ToUpper(p[:1]) + p[1:]
+	}
+	return out
+}
+
+func buildNodeRouteData(models []Model, isMySQL bool) nodeRoutesData {
+	nodeModels := make([]nodeModelData, 0, len(models))
+	for _, m := range models {
+		sortCols := []string{"id"}
+		if modelHasTimestamps(m) {
+			sortCols = append(sortCols, "createdAt", "updatedAt")
+		}
+		var searchCols []string
+		var filterCols []nodeFilterColumn
+		for _, f := range m.Fields {
+			sortCols = append(sortCols, toCamelCase(f.Name))
+			lower := strings.ToLower(f.Type)
+			isText := strings.HasPrefix(lower, "text") || strings.HasPrefix(lower, "varchar") || strings.HasPrefix(lower, "char")
+			if isText {
+				searchCols = append(searchCols, toCamelCase(f.Name))
+			}
+			isNum := lower == "int" || lower == "bigint" || lower == "smallint" ||
+				lower == "float" || lower == "double" || strings.HasPrefix(lower, "decimal") ||
+				f.References != ""
+			isBool := lower == "boolean" || lower == "bool"
+			filterCols = append(filterCols, nodeFilterColumn{
+				Name:      toCamelCase(f.Name),
+				IsNumeric: isNum,
+				IsBool:    isBool,
+			})
+		}
+		var m2mRels []nodeM2MRelation
+		for _, other := range m.ManyToMany {
+			jt := joinTableName(m.Name, other)
+			otherStruct := toPascalCase(toSingular(other))
+			m2mRels = append(m2mRels, nodeM2MRelation{
+				Field:     toCamelCase(other),
+				ModelName: otherStruct,
+				IdsField:  toSingular(other) + "_ids",
+				JoinTable: jt,
+			})
+		}
+		nodeModels = append(nodeModels, nodeModelData{
+			Name:          m.Name,
+			CamelName:     toCamelCase(toSingular(m.Name)),
+			SortColumns:   sortCols,
+			SearchColumns: searchCols,
+			FilterColumns: filterCols,
+			HasM2M:        len(m2mRels) > 0,
+			M2MRelations:  m2mRels,
+			HasPlainFields: len(m.Fields) > 0,
+		})
+	}
+	return nodeRoutesData{Models: nodeModels, IsPg: !isMySQL}
+}
+
+func GenerateNodeRoutes(cfg *Config) (string, error) {
+	data := buildNodeRouteData(cfg.Models, cfg.Database.Driver == "mysql")
+	var buf strings.Builder
+	if err := template.Must(template.New("node_routes_js").Parse(nodeRoutesJSTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute node_routes_js template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ── auth.js ───────────────────────────────────────────────────────────────────
+
+func GenerateNodeAuth(cfg *Config) (string, error) {
+	if cfg.Auth == nil {
+		return "", fmt.Errorf("auth config is not set")
+	}
+	var authModel Model
+	for _, m := range cfg.Models {
+		if m.Name == cfg.Auth.Model {
+			authModel = m
+			break
+		}
+	}
+	identityField := detectIdentityField(authModel)
+	data := struct {
+		IdentityField string
+		ModelCamel    string
+	}{
+		IdentityField: identityField,
+		ModelCamel:    toCamelCase(toSingular(authModel.Name)),
+	}
+	var buf strings.Builder
+	if err := template.Must(template.New("node_auth_js").Parse(nodeAuthJSTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute node_auth_js template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ── prisma/schema.prisma ──────────────────────────────────────────────────────
+
+type prismaFieldData struct {
+	Name       string
+	PrismaType string
+	IsRequired bool
+	Attrs      []string
+}
+
+type prismaM2MRelation struct {
+	Field     string
+	ModelName string
+	JoinTable string
+}
+
+type prismaBackRelation struct {
+	Field     string
+	ModelName string
+}
+
+type prismaModelData struct {
+	StructName    string
+	TableName     string
+	HasTimestamps bool
+	Fields        []prismaFieldData
+	M2MRelations  []prismaM2MRelation
+	BackRelations []prismaBackRelation
+}
+
+type prismaSchemaData struct {
+	DBProvider string
+	Models     []prismaModelData
+}
+
+func sqlTypeToPrisma(f Field) (prismaType string, attrs []string) {
+	lower := strings.ToLower(f.Type)
+	switch {
+	case strings.HasPrefix(lower, "varchar"), strings.HasPrefix(lower, "char"), lower == "text", lower == "enum":
+		prismaType = "String"
+	case lower == "int", lower == "smallint":
+		prismaType = "Int"
+	case lower == "bigint":
+		prismaType = "BigInt"
+	case lower == "boolean", lower == "bool":
+		prismaType = "Boolean"
+	case lower == "date":
+		prismaType = "DateTime"
+	case lower == "datetime", lower == "timestamp":
+		prismaType = "DateTime"
+	case lower == "float", lower == "double":
+		prismaType = "Float"
+	case strings.HasPrefix(lower, "decimal"):
+		prismaType = "Decimal"
+	case lower == "uuid":
+		prismaType = "String"
+		attrs = append(attrs, "@db.Uuid")
+	default:
+		prismaType = "String"
+	}
+
+	if f.References != "" {
+		prismaType = "Int"
+		if !f.Required {
+			prismaType = "Int?"
+		}
+	}
+
+	if f.Default != nil {
+		attrs = append(attrs, fmt.Sprintf("@default(%v)", f.Default))
+	}
+	if f.Unique {
+		attrs = append(attrs, "@unique")
+	}
+	if f.Index && !f.Unique {
+		attrs = append(attrs, "// @index — add @@index(["+f.Name+"]) at model level if needed")
+	}
+	if f.References != "" {
+		parts := strings.SplitN(f.References, ".", 2)
+		attrs = append(attrs, fmt.Sprintf("@relation(fields: [%s], references: [%s])", f.Name, parts[1]))
+	}
+	return
+}
+
+func GenerateNodePrismaSchema(cfg *Config) (string, error) {
+	dbProvider := "postgresql"
+	if cfg.Database.Driver == "mysql" {
+		dbProvider = "mysql"
+	}
+
+	// build a map of which models are referenced (back-relations)
+	type backRef struct {
+		fromModel string
+		fieldName string
+	}
+	backRefs := make(map[string][]backRef) // key = referenced model name
+	for _, m := range cfg.Models {
+		for _, f := range m.Fields {
+			if f.References != "" {
+				parts := strings.SplitN(f.References, ".", 2)
+				refModel := parts[0]
+				backRefs[refModel] = append(backRefs[refModel], backRef{
+					fromModel: m.Name,
+					fieldName: toCamelCase(m.Name),
+				})
+			}
+		}
+	}
+
+	prismaModels := make([]prismaModelData, 0, len(cfg.Models))
+	for _, m := range cfg.Models {
+		structName := toPascalCase(toSingular(m.Name))
+		fields := make([]prismaFieldData, 0, len(m.Fields))
+		for _, f := range m.Fields {
+			pt, attrs := sqlTypeToPrisma(f)
+			mapAttr := fmt.Sprintf("@map(\"%s\")", f.Name)
+			allAttrs := append([]string{mapAttr}, attrs...)
+
+			isReq := f.Required
+			if f.References != "" {
+				// The FK field itself (e.g. user_id Int?)
+				fields = append(fields, prismaFieldData{
+					Name:       toCamelCase(f.Name),
+					PrismaType: pt,
+					IsRequired: isReq,
+					Attrs:      []string{mapAttr},
+				})
+				// The relation field (e.g. user User @relation(...))
+				refParts := strings.SplitN(f.References, ".", 2)
+				refStruct := toPascalCase(toSingular(refParts[0]))
+				relType := refStruct
+				if !f.Required {
+					relType = refStruct + "?"
+				}
+				relAttr := fmt.Sprintf("@relation(fields: [%s], references: [%s])", toCamelCase(f.Name), refParts[1])
+				assocName := strings.TrimSuffix(toCamelCase(f.Name), "Id")
+				if assocName == toCamelCase(f.Name) {
+					assocName = toCamelCase(toSingular(refParts[0]))
+				}
+				fields = append(fields, prismaFieldData{
+					Name:       assocName,
+					PrismaType: relType,
+					IsRequired: false,
+					Attrs:      []string{relAttr},
+				})
+				continue
+			}
+			fields = append(fields, prismaFieldData{
+				Name:       toCamelCase(f.Name),
+				PrismaType: pt + func() string { if !isReq { return "?" }; return "" }(),
+				IsRequired: isReq,
+				Attrs:      allAttrs,
+			})
+		}
+
+		var m2mRels []prismaM2MRelation
+		for _, other := range m.ManyToMany {
+			jt := joinTableName(m.Name, other)
+			otherStruct := toPascalCase(toSingular(other))
+			m2mRels = append(m2mRels, prismaM2MRelation{
+				Field:     toCamelCase(other),
+				ModelName: otherStruct,
+				JoinTable: jt,
+			})
+		}
+
+		var backRel []prismaBackRelation
+		for _, br := range backRefs[m.Name] {
+			fromStruct := toPascalCase(toSingular(br.fromModel))
+			backRel = append(backRel, prismaBackRelation{
+				Field:     toCamelCase(br.fromModel),
+				ModelName: fromStruct + "[]",
+			})
+		}
+
+		prismaModels = append(prismaModels, prismaModelData{
+			StructName:    structName,
+			TableName:     m.Name,
+			HasTimestamps: modelHasTimestamps(m),
+			Fields:        fields,
+			M2MRelations:  m2mRels,
+			BackRelations: backRel,
+		})
+	}
+
+	data := prismaSchemaData{DBProvider: dbProvider, Models: prismaModels}
+	var buf strings.Builder
+	if err := template.Must(template.New("node_prisma_schema").Parse(nodePrismaSchmaTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute node_prisma_schema template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ── dev.sh (node variant) ─────────────────────────────────────────────────────
+
+func GenerateNodeDevScript(cfg *Config) (string, error) {
+	data := struct {
+		Port    int
+		IsMySQL bool
+	}{Port: cfg.App.Port, IsMySQL: cfg.Database.Driver == "mysql"}
+	var buf strings.Builder
+	if err := template.Must(template.New("node_dev_sh").Parse(nodeDevShTmpl)).Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute node_dev_sh template: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/internal/generator/templates/node_auth_js.tmpl
+++ b/internal/generator/templates/node_auth_js.tmpl
@@ -1,0 +1,51 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'change-me-in-production';
+
+export function jwtMiddleware(req, res, next) {
+  const header = req.headers['authorization'] || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'unauthorized' });
+  try {
+    req.user = jwt.verify(token, JWT_SECRET);
+    next();
+  } catch {
+    res.status(401).json({ error: 'invalid token' });
+  }
+}
+
+export function registerAuthRoutes(app, prisma) {
+  app.post('/api/auth/register', async (req, res) => {
+    try {
+      const { {{.IdentityField}}, password, ...rest } = req.body;
+      const hash = await bcrypt.hash(password, 10);
+      const user = await prisma.{{.ModelCamel}}.create({
+        data: { {{.IdentityField}}, password: hash, ...rest },
+      });
+      res.status(201).json({ id: user.id });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.post('/api/auth/login', async (req, res) => {
+    try {
+      const { {{.IdentityField}}, password } = req.body;
+      const user = await prisma.{{.ModelCamel}}.findFirst({
+        where: { {{.IdentityField}} },
+      });
+      if (!user || !(await bcrypt.compare(password, user.password))) {
+        return res.status(401).json({ error: 'invalid credentials' });
+      }
+      const token = jwt.sign(
+        { userId: user.id, {{.IdentityField}}: user.{{.IdentityField}} },
+        JWT_SECRET,
+        { expiresIn: '24h' },
+      );
+      res.json({ token });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+}

--- a/internal/generator/templates/node_dev_sh.tmpl
+++ b/internal/generator/templates/node_dev_sh.tmpl
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Load .env if present
+if [ -f .env ]; then
+  set -a && source .env && set +a
+fi
+
+# ── 1. Database ────────────────────────────────────────────────────────────────
+echo "▸ Starting database..."
+{{if .IsMySQL}}docker compose up -d mysql
+
+echo -n "▸ Waiting for database to be ready..."
+until docker compose exec -T mysql mysqladmin ping -h 127.0.0.1 -uroot -p"$DB_PASSWORD" >/dev/null 2>&1; do
+  printf "."
+  sleep 1
+done
+echo " ready"
+{{else}}docker compose up -d postgres
+
+echo -n "▸ Waiting for database to be ready..."
+until docker compose exec -T postgres pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; do
+  printf "."
+  sleep 1
+done
+echo " ready"
+{{end}}
+# ── 2. Migrations (Prisma) ─────────────────────────────────────────────────────
+echo "▸ Applying migrations..."
+npx prisma migrate deploy
+echo "  migrations applied"
+
+# ── 3. Server ──────────────────────────────────────────────────────────────────
+echo "▸ Installing server dependencies..."
+npm install
+
+echo "▸ Starting server on port {{.Port}} (background)..."
+npm run dev &
+SERVER_PID=$!
+
+# ── 4. Client ──────────────────────────────────────────────────────────────────
+echo "▸ Installing client dependencies..."
+(cd client && npm install)
+
+echo "▸ Starting client dev server..."
+(cd client && npm run dev) &
+CLIENT_PID=$!
+
+# Open browser after short delay
+(sleep 5 && open "http://localhost:5173") &
+
+trap "kill $SERVER_PID $CLIENT_PID 2>/dev/null; exit" INT TERM
+wait $SERVER_PID $CLIENT_PID

--- a/internal/generator/templates/node_index_js.tmpl
+++ b/internal/generator/templates/node_index_js.tmpl
@@ -1,0 +1,32 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+import { registerRoutes } from './routes.js';
+{{if .HasAuth}}import { registerAuthRoutes, jwtMiddleware } from './auth.js';
+{{end}}
+const app = express();
+const prisma = new PrismaClient();
+
+app.use(express.json());
+
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') return res.sendStatus(204);
+  next();
+});
+
+{{if .HasAuth}}registerAuthRoutes(app, prisma);
+
+const api = express.Router();
+api.use(jwtMiddleware);
+registerRoutes(api, prisma);
+app.use('/api', api);
+{{else}}const api = express.Router();
+registerRoutes(api, prisma);
+app.use('/api', api);
+{{end}}
+const port = process.env.APP_PORT || {{.Port}};
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/internal/generator/templates/node_package_json.tmpl
+++ b/internal/generator/templates/node_package_json.tmpl
@@ -1,0 +1,18 @@
+{
+  "name": "{{.AppName}}",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.14.0",
+    "express": "^4.19.2"{{if .HasAuth}},
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"{{end}}
+  },
+  "devDependencies": {
+    "prisma": "^5.14.0"
+  }
+}

--- a/internal/generator/templates/node_prisma_schema.tmpl
+++ b/internal/generator/templates/node_prisma_schema.tmpl
@@ -1,0 +1,22 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "{{.DBProvider}}"
+  url      = env("DATABASE_URL")
+}
+
+{{range .Models}}model {{.StructName}} {
+  id  Int  @id @default(autoincrement())
+{{range .Fields}}  {{.Name}}  {{.PrismaType}}{{if .IsRequired}} {{end}}{{range .Attrs}} {{.}}{{end}}
+{{end}}{{if .HasTimestamps}}  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @updatedAt @map("updated_at")
+  deletedAt  DateTime? @map("deleted_at")
+{{end}}{{range .M2MRelations}}  {{.Field}}  {{.ModelName}}[]  @relation("{{.JoinTable}}")
+{{end}}{{range .BackRelations}}  {{.Field}}  {{.ModelName}}[]
+{{end}}
+  @@map("{{.TableName}}")
+}
+
+{{end}}

--- a/internal/generator/templates/node_routes_js.tmpl
+++ b/internal/generator/templates/node_routes_js.tmpl
@@ -1,0 +1,108 @@
+export function registerRoutes(router, prisma) {
+{{range .Models}}  // ── {{.Name}} ──────────────────────────────────────────────────────────────
+
+  router.get('/{{.Name}}', async (req, res) => {
+    try {
+      const page = Math.max(1, parseInt(req.query.page) || 1);
+      const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 20));
+      const skip = (page - 1) * limit;
+      const allowedSort = [{{range $i, $c := .SortColumns}}{{if $i}}, {{end}}'{{$c}}'{{end}}];
+      const sortBy = allowedSort.includes(req.query.sort_by) ? req.query.sort_by : 'id';
+      const sortDir = req.query.sort_dir === 'asc' ? 'asc' : 'desc';
+
+      const where = {};
+{{if .SearchColumns}}      if (req.query.q) {
+        where.OR = [{{range $i, $c := .SearchColumns}}{{if $i}}, {{end}}{ {{$c}}: { contains: req.query.q{{if $.IsPg}}, mode: 'insensitive'{{end}} } }{{end}}];
+      }
+{{end}}{{range .FilterColumns}}      if (req.query.{{.Name}} !== undefined) {
+{{if .IsNumeric}}        const n = parseInt(req.query.{{.Name}});
+        if (!isNaN(n)) where.{{.Name}} = n;
+{{else if .IsBool}}        if (req.query.{{.Name}} === 'true' || req.query.{{.Name}} === '1') where.{{.Name}} = true;
+        else if (req.query.{{.Name}} === 'false' || req.query.{{.Name}} === '0') where.{{.Name}} = false;
+{{else}}        where.{{.Name}} = req.query.{{.Name}};
+{{end}}      }
+{{end}}
+      const [data, total] = await prisma.$transaction([
+        prisma.{{.CamelName}}.findMany({
+          where,
+          skip,
+          take: limit,
+          orderBy: { [sortBy]: sortDir },{{if .HasM2M}}
+          include: { {{range $i, $r := .M2MRelations}}{{if $i}}, {{end}}{{$r.Field}}: true{{end}} },{{end}}
+        }),
+        prisma.{{.CamelName}}.count({ where }),
+      ]);
+
+      res.json({ data, total, page, limit });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.get('/{{.Name}}/:id', async (req, res) => {
+    try {
+      const row = await prisma.{{.CamelName}}.findUnique({
+        where: { id: parseInt(req.params.id) },{{if .HasM2M}}
+        include: { {{range $i, $r := .M2MRelations}}{{if $i}}, {{end}}{{$r.Field}}: true{{end}} },{{end}}
+      });
+      if (!row) return res.status(404).json({ error: 'not found' });
+      res.json(row);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.post('/{{.Name}}', async (req, res) => {
+    try {
+      const { {{range $i, $r := .M2MRelations}}{{if $i}}, {{end}}{{$r.IdsField}}{{end}}{{if and .HasM2M .HasPlainFields}}, {{end}}...data } = req.body;
+      const row = await prisma.{{.CamelName}}.create({
+        data: {
+          ...data,{{range .M2MRelations}}
+          {{.Field}}: {{.IdsField}} ? { connect: {{.IdsField}}.map(id => ({ id })) } : undefined,{{end}}
+        },{{if .HasM2M}}
+        include: { {{range $i, $r := .M2MRelations}}{{if $i}}, {{end}}{{$r.Field}}: true{{end}} },{{end}}
+      });
+      res.status(201).json(row);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.put('/{{.Name}}/:id', async (req, res) => {
+    try {
+      const { {{range $i, $r := .M2MRelations}}{{if $i}}, {{end}}{{$r.IdsField}}{{end}}{{if and .HasM2M .HasPlainFields}}, {{end}}...data } = req.body;
+      const row = await prisma.{{.CamelName}}.update({
+        where: { id: parseInt(req.params.id) },
+        data: {
+          ...data,{{range .M2MRelations}}
+          {{.Field}}: {{.IdsField}} ? { set: {{.IdsField}}.map(id => ({ id })) } : undefined,{{end}}
+        },{{if .HasM2M}}
+        include: { {{range $i, $r := .M2MRelations}}{{if $i}}, {{end}}{{$r.Field}}: true{{end}} },{{end}}
+      });
+      res.json(row);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.delete('/{{.Name}}/batch', async (req, res) => {
+    try {
+      const { ids } = req.body;
+      if (!ids || ids.length === 0) return res.status(400).json({ error: 'ids required' });
+      await prisma.{{.CamelName}}.deleteMany({ where: { id: { in: ids } } });
+      res.sendStatus(204);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.delete('/{{.Name}}/:id', async (req, res) => {
+    try {
+      await prisma.{{.CamelName}}.delete({ where: { id: parseInt(req.params.id) } });
+      res.sendStatus(204);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+{{end}}}


### PR DESCRIPTION
## What changed

Added `app.server` as a new config option that lets users choose between a **Go (Gin + GORM)** backend (default) and a new **Node.js (Express + Prisma)** backend when generating an application with gaplicator.

```yaml
app:
  name: my-app
  port: 8080
  server: node  # "go" (default) or "node"
```

## Why

The Go backend is a solid default, but many teams are more comfortable shipping Node.js. This PR makes gaplicator a first-class generator for both stacks without changing any existing behaviour — `server: go` (or omitting the field) continues to work exactly as before.

## Implementation details

### Config (`internal/generator/generator.go`)
- Added `Server string` field to `AppConfig` with YAML tag `server`
- Default `"go"` is applied in both `ParseConfig` (YAML path) and `ValidateConfig` (direct struct construction, e.g. tests)
- Validation rejects any value other than `"go"` or `"node"`

### Node.js templates (`internal/generator/templates/node_*.tmpl`)
| Template | Output |
|---|---|
| `node_package_json.tmpl` | `package.json` — Express, `@prisma/client`, optional `bcryptjs`/`jsonwebtoken` |
| `node_index_js.tmpl` | `index.js` — Express server, CORS, conditional JWT middleware |
| `node_routes_js.tmpl` | `routes.js` — full CRUD per model: pagination, search, filters, M2M via Prisma `connect`/`set` |
| `node_auth_js.tmpl` | `auth.js` — bcrypt register + JWT login + middleware |
| `node_prisma_schema.tmpl` | `prisma/schema.prisma` — models, FK relations, M2M, timestamps, `@@map` |
| `node_dev_sh.tmpl` | `dev.sh` — DB startup → `prisma migrate deploy` → `npm run dev` → React client |

### Generator functions (`internal/generator/node_generator.go`)
New file with: `GenerateNodePackageJSON`, `GenerateNodeIndex`, `GenerateNodeRoutes`, `GenerateNodeAuth`, `GenerateNodePrismaSchema`, `GenerateNodeDevScript`. Shared helpers (`toCamelCase`, `sqlTypeToPrisma`, etc.) live here alongside the data-building logic.

### Build pipeline (`cmd/build.go`)
`build.go` now branches on `cfg.App.Server`:
- **`"node"`** — emits `package.json`, `index.js`, `routes.js`, `auth.js`, `prisma/schema.prisma`, Node-flavoured `dev.sh`
- **`"go"`** — existing Go pipeline unchanged (`migrations/`, `models/`, `routes/`, `main.go`, `go.mod`, …)

Both paths share: `docker-compose.yml`, `.env`, `shutdown.sh`, `README.md`, and the React client.

### Test fixes
Three pre-existing test assertions referenced pre-`/api`-prefix route strings. Updated to match the current template output.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)