### PR TITLE
Add root dev.sh to bootstrap bridge and web app together (Vibe Kanban)

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+BRIDGE_HOST="${BRIDGE_HOST:-127.0.0.1}"
+BRIDGE_PORT="${BRIDGE_PORT:-8787}"
+WEB_PORT="${WEB_PORT:-5173}"
+
+cleanup() {
+  if [ -n "${BRIDGE_PID:-}" ]; then
+    kill "$BRIDGE_PID" 2>/dev/null || true
+  fi
+  if [ -n "${WEB_PID:-}" ]; then
+    kill "$WEB_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
+echo "▸ Starting bridge on http://${BRIDGE_HOST}:${BRIDGE_PORT}..."
+GOTOOLCHAIN=local go run . serve --host "$BRIDGE_HOST" --port "$BRIDGE_PORT" &
+BRIDGE_PID=$!
+
+echo "▸ Starting web app on http://127.0.0.1:${WEB_PORT}..."
+(cd web && npm run dev -- --host 127.0.0.1 --port "$WEB_PORT") &
+WEB_PID=$!
+
+wait "$BRIDGE_PID" "$WEB_PID"


### PR DESCRIPTION
## Summary
This PR adds a new root-level `dev.sh` bootstrap script to start the local bridge and web app together in one command.

## What Changed
- Added executable `dev.sh` at the repository root.
- Script starts the Go bridge via:
  - `go run . serve --host "$BRIDGE_HOST" --port "$BRIDGE_PORT"`
- Script starts the web app via:
  - `cd web && npm run dev -- --host 127.0.0.1 --port "$WEB_PORT"`
- Added process cleanup with `trap` so both child processes are terminated on `INT`, `TERM`, or script exit.
- Added configurable environment variables with defaults:
  - `BRIDGE_HOST` (default `127.0.0.1`)
  - `BRIDGE_PORT` (default `8787`)
  - `WEB_PORT` (default `5173`)

## Why
The task context requested a bootstrap script (`dev.sh`) that runs both the web app and bridge. Previously, these had to be started manually in separate terminals. This script reduces setup friction for local development and provides a single entrypoint for the schema-generator + bridge workflow.

## Implementation Details
- `set -euo pipefail` is used for safer shell execution.
- `cd "$(dirname "$0")"` ensures execution is relative to repo root regardless of where the script is called from.
- `wait` is used to keep the script attached to both background processes.

This PR was written using [Vibe Kanban](https://vibekanban.com)
