### PR TITLE
Add dev bootstrap script and README startup flow for bridge + web app (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,23 @@ gaplicator serve [--host <host>] [--port <port>]
 
 ### Web Bridge (schema generator -> CLI)
 
-Run a local bridge so the web app can send generated YAML directly to the CLI:
+Run both the bridge and web schema generator with one command:
 
 ```bash
-gaplicator serve --host 127.0.0.1 --port 8787
+./dev.sh
 ```
 
-Run the web schema generator in a separate terminal:
+This starts:
+- bridge at `http://127.0.0.1:8787`
+- web app at `http://127.0.0.1:5173`
+
+Manual alternative (two terminals):
 
 ```bash
+# terminal 1
+gaplicator serve --host 127.0.0.1 --port 8787
+
+# terminal 2
 cd web
 npm install
 npm run dev


### PR DESCRIPTION
## Summary
This PR introduces a root-level bootstrap script and updates the docs for running the local bridge + web schema generator workflow.

## What Changed
- Added executable `dev.sh` in the repository root.
- `dev.sh` starts both services together:
  - Bridge: `go run . serve --host "$BRIDGE_HOST" --port "$BRIDGE_PORT"`
  - Web app: `cd web && npm run dev -- --host 127.0.0.1 --port "$WEB_PORT"`
- Added process cleanup in `dev.sh` using `trap` so both background processes are terminated on exit/signals.
- Added env-based defaults in `dev.sh`:
  - `BRIDGE_HOST` (default `127.0.0.1`)
  - `BRIDGE_PORT` (default `8787`)
  - `WEB_PORT` (default `5173`)
- Updated `README.md` Web Bridge section to document `./dev.sh` as the primary workflow, while keeping the two-terminal manual alternative.

## Why
Task context requested a bootstrap script (`dev.sh`) that runs the web app and bridge together. The README update aligns documentation with this new developer workflow, reducing setup friction and making local startup faster and less error-prone.

## Important Implementation Details
- `set -euo pipefail` is enabled for safer script execution.
- `cd "$(dirname "$0")"` ensures the script runs correctly from any current working directory.
- `wait "$BRIDGE_PID" "$WEB_PID"` keeps the script attached to both services.
- README now clearly documents expected local endpoints (`127.0.0.1:8787` and `127.0.0.1:5173`).

This PR was written using [Vibe Kanban](https://vibekanban.com)
